### PR TITLE
#10: Fixed website spelling errors

### DIFF
--- a/website/src/index.html
+++ b/website/src/index.html
@@ -84,7 +84,7 @@
                         <h1>Introduction</h1>
                         <p>
                             Jitar is a full-stack JavaScript runtime for small to large web applications.
-                            It lets you to build monolithic applications and run them spread out over multiple servers and web browsers.
+                            It lets you build monolithic applications and run them spread out over multiple servers and web browsers.
                             Jitar takes care of the inner communication, so you don't have to build any API.
                         </p>
                         <p>
@@ -160,7 +160,7 @@
                     <h1>Features</h1>
                     <p>
                         The main feature is writing monolithic applications that scale in any form and closes the gap between front- and back-end.
-                        It doesn't matter if a component is placed on of the servers or the web browser. Jitar will make it work using its powerful runtime features.
+                        It doesn't matter if a component is placed on one of the servers or the web browser. Jitar will make it work using its powerful runtime features.
                     </p>
                     <div class="cards">
                         <div class="card">


### PR DESCRIPTION
- removed "to" from the introduction section
- added "one" to the feature section