### PR TITLE
fix(caching): import commonjs modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,12 +96,21 @@
         "examples/2-advanced/1-start-hooks": {
             "name": "jitar-start-hooks-example",
             "dependencies": {
+                "dotenv": "^16.0.3",
                 "jitar-nodejs-server": "^0.3.4"
             },
             "devDependencies": {
                 "cpx2": "^4.2.0",
                 "npm-run-all": "^4.1.5",
                 "rimraf": "^4.1.2"
+            }
+        },
+        "examples/2-advanced/1-start-hooks/node_modules/dotenv": {
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+            "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "examples/2-advanced/1-start-hooks/node_modules/rimraf": {
@@ -11738,17 +11747,17 @@
             }
         },
         "packages/jitar": {
-            "version": "0.3.4",
+            "version": "0.3.6",
             "license": "MIT",
             "dependencies": {
-                "jitar-reflection": "^0.3.4"
+                "jitar-reflection": "^0.3.6"
             },
             "engines": {
                 "node": ">=18.7"
             }
         },
         "packages/jitar-nodejs-server": {
-            "version": "0.3.4",
+            "version": "0.3.6",
             "license": "MIT",
             "dependencies": {
                 "@overnightjs/core": "^1.7.6",
@@ -11817,14 +11826,14 @@
             }
         },
         "packages/jitar-reflection": {
-            "version": "0.3.5",
+            "version": "0.3.6",
             "license": "MIT"
         },
         "packages/jitar-vite-plugin": {
-            "version": "0.3.4",
+            "version": "0.3.6",
             "license": "MIT",
             "dependencies": {
-                "jitar-reflection": "^0.3.4"
+                "jitar-reflection": "^0.3.6"
             },
             "peerDependencies": {
                 "vite": "^4.1.4"

--- a/packages/jitar-reflection/src/Reflector.ts
+++ b/packages/jitar-reflection/src/Reflector.ts
@@ -3,8 +3,10 @@ import Parser from './parser/Parser.js';
 
 import ReflectionClass from './models/ReflectionClass.js';
 import ReflectionExpression from './models/ReflectionExpression.js';
+import ReflectionExport from './models/ReflectionExport.js';
 import ReflectionField from './models/ReflectionField.js';
 import ReflectionFunction from './models/ReflectionFunction.js';
+import ReflectionImport from './models/ReflectionImport.js';
 import ReflectionModule from './models/ReflectionModule.js';
 import ReflectionScope from './models/ReflectionScope.js';
 
@@ -35,6 +37,16 @@ export default class Reflector
     parseField(code: string): ReflectionField
     {
         return this.#parser.parseField(code);
+    }
+
+    parseImport(code: string): ReflectionImport
+    {
+        return this.#parser.parseImport(code);
+    }
+
+    parseExport(code: string): ReflectionExport
+    {
+        return this.#parser.parseExport(code);
     }
 
     fromModule(module: object, inherit = false): ReflectionModule

--- a/packages/jitar-reflection/src/parser/Parser.ts
+++ b/packages/jitar-reflection/src/parser/Parser.ts
@@ -273,7 +273,9 @@ export default class Parser
 
         if (token.hasValue(Scope.OPEN) === false)
         {
-            const name = DEFAULT_IDENTIFIER;
+            // Keep the * indicator, otherwise use the default identifier
+            const name = token.hasValue(Operator.MULTIPLY) ? Operator.MULTIPLY : DEFAULT_IDENTIFIER;
+            
             let as = token.value;
 
             token = tokenList.step(); // Read away the name

--- a/packages/jitar-reflection/test/parser/Parser.spec.ts
+++ b/packages/jitar-reflection/test/parser/Parser.spec.ts
@@ -97,7 +97,7 @@ describe('parser/Parser', () =>
             expect(imported.from).toBe("'module'");
 
             const member = imported.members[0];
-            expect(member.name).toBe('default');
+            expect(member.name).toBe('*');
             expect(member.as).toBe('name');
         });
 

--- a/packages/jitar/test/_fixtures/runtime/caching/ImportRewriter.fixture.ts
+++ b/packages/jitar/test/_fixtures/runtime/caching/ImportRewriter.fixture.ts
@@ -8,7 +8,7 @@ import { component1, component2 } from '../path/to/components.js';
 const noSystemImportsResult = noSystemImports;
 
 const hasSystemImports =
-    `import fs from 'fs';
+    `import * as fs from 'fs';
 import component from 'http';
 import { component1, component2 } from 'https';
 `;
@@ -16,7 +16,7 @@ import { component1, component2 } from 'https';
 const hasSystemImportsResult =
     `import { getDependency } from "/jitar/hooks.js";
 const fs = await getDependency('fs');
-const component = await getDependency('http');
+const { default: component } = await getDependency('http');
 const { component1, component2 } = await getDependency('https');
 `;
 
@@ -41,7 +41,7 @@ import { runProcedure } from 'jitar';
 const hasMixedImportsResult =
     `import { getDependency } from "/jitar/hooks.js";
 import component from './path/to/component.js';
-const os = await getDependency('os');
+const { default: os } = await getDependency('os');
 import { runProcedure } from "/jitar/hooks.js";
 `;
 
@@ -62,7 +62,7 @@ import { runProcedure } from 'jitar';
 
 const hasImportsAndContentResult =
     `import { getDependency } from "/jitar/hooks.js";
-const os = await getDependency('os');
+const { default: os } = await getDependency('os');
 
 export default function test() {}
 


### PR DESCRIPTION
Fixes #181 

Changes proposed in this pull request:
- Exposed parsing imports and exports in the reflector
- Preserved the * as import name when importing all module members
- Added support for importing module members (actual fix)

@MaskingTechnology/jitar
