### PR TITLE
chore(build): add node 20 to ci pipeline

### DIFF
--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 19.x]
+        node-version: [18.x, 19.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fixes #266 

Changes proposed in this pull request:
- Added node 20.x to ci pipeline

@MaskingTechnology/jitar
