### PR TITLE
feat(server): default cache location to .jitar folder

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,4 +1,4 @@
 dist
-cache
+.jitar
 node_modules
 package-lock.json

--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,5 +1,6 @@
 coverage
 dist
 cache
+.jitar
 node_modules
 **/*.tgz

--- a/packages/create-jitar/templates/jitar-only/_gitignore
+++ b/packages/create-jitar/templates/jitar-only/_gitignore
@@ -8,7 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-cache
+.jitar
 dist
 dist-ssr
 *.local

--- a/packages/create-jitar/templates/lit/_gitignore
+++ b/packages/create-jitar/templates/lit/_gitignore
@@ -8,7 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-cache
+.jitar
 dist
 dist-ssr
 *.local

--- a/packages/create-jitar/templates/react/_gitignore
+++ b/packages/create-jitar/templates/react/_gitignore
@@ -8,7 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-cache
+.jitar
 dist
 dist-ssr
 *.local

--- a/packages/create-jitar/templates/solid/_gitignore
+++ b/packages/create-jitar/templates/solid/_gitignore
@@ -9,7 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
-cache
+.jitar
 dist-ssr
 *.local
 

--- a/packages/create-jitar/templates/svelte/_gitignore
+++ b/packages/create-jitar/templates/svelte/_gitignore
@@ -8,7 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-cache
+.jitar
 dist
 dist-ssr
 *.local

--- a/packages/create-jitar/templates/vue/_gitignore
+++ b/packages/create-jitar/templates/vue/_gitignore
@@ -9,7 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
-cache
+.jitar
 dist-ssr
 *.local
 

--- a/packages/server-nodejs/src/definitions/RuntimeDefaults.ts
+++ b/packages/server-nodejs/src/definitions/RuntimeDefaults.ts
@@ -3,7 +3,7 @@ enum RuntimeDefaults
 {
     URL = 'http://localhost:3000',
     SOURCE = './src',
-    CACHE = './cache',
+    CACHE = './.jitar',
     INDEX = 'index.html'
 }
 


### PR DESCRIPTION
Fixes #279 

Changes proposed in this pull request:
- Updated the default cache location to .jitar
- Updated the starters to ignore .jitar

@MaskingTechnology/jitar
