### PR TITLE
fix(server): non-string primitive type response

### DIFF
--- a/packages/server-nodejs/src/configuration/ServerOptions.ts
+++ b/packages/server-nodejs/src/configuration/ServerOptions.ts
@@ -12,7 +12,7 @@ export const serverOptionsSchema = z
 export default class ServerOptions
 {
     #config: string;
-    #loglevel?: string;
+    #loglevel: string;
 
     constructor(config: string, loglevel = 'info')
     {

--- a/packages/server-nodejs/src/controllers/HealthController.ts
+++ b/packages/server-nodejs/src/controllers/HealthController.ts
@@ -34,6 +34,8 @@ export default class HealthController
 
         this.#logger.debug('Got health status');
 
+        response.setHeader('Content-Type', 'text/plain');
+
         return response.status(200).send(healthy);
     }
 }

--- a/packages/server-nodejs/src/controllers/RPCController.ts
+++ b/packages/server-nodejs/src/controllers/RPCController.ts
@@ -168,7 +168,7 @@ export default class RPCController
 
             const result = await this.#runtime.handle(fqn, version, argsMap, headers);
 
-            this.#logger.info(`Ran procedure -> ${fqn} (${version.toString()})`);
+            this.#logger.info(`Ran procedure -> ${fqn} (v${version.toString()})`);
 
             this.#setResponseHeaders(response, headers);
 
@@ -182,7 +182,7 @@ export default class RPCController
             const message = error instanceof Error ? error.message : String(error);
             const errorData = serialize ? error : message;
 
-            this.#logger.error(`Failed to run procedure -> ${fqn} (${version.toString()}) | ${message}`);
+            this.#logger.error(`Failed to run procedure -> ${fqn} (v${version.toString()}) | ${message}`);
 
             return this.#createErrorResponse(error, errorData, response, serialize);
         }
@@ -209,10 +209,11 @@ export default class RPCController
     {
         const content = await this.#createResponseContent(result, serialize);
         const contentType = this.#createResponseContentType(content);
+        const responseContent = contentType === 'text/plain' ? String(content) : content;
 
         response.setHeader('Content-Type', contentType);
 
-        return response.status(200).send(content);
+        return response.status(200).send(responseContent);
     }
 
     async #createErrorResponse(error: unknown, errorData: unknown, response: Response, serialize: boolean): Promise<Response>


### PR DESCRIPTION
Fixes #292 

Changes proposed in this pull request:
- Fixed loglevel configuration property
- Assured to return either a string or an object as response value

@MaskingTechnology/jitar
