### PR TITLE
chore(packaging): @jitar deps to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12873,8 +12873,6 @@
             "version": "0.4.0",
             "license": "MIT",
             "dependencies": {
-                "@jitar/runtime": "^0.4.0",
-                "@jitar/server-nodejs": "^0.4.0",
                 "express": "^4.18.2",
                 "express-http-proxy": "^1.6.3",
                 "fs-extra": "^11.1.1",
@@ -12883,6 +12881,10 @@
                 "tslog": "^4.8.2",
                 "yargs": "^17.7.2",
                 "zod": "^3.21.4"
+            },
+            "devDependencies": {
+                "@jitar/runtime": "^0.4.0",
+                "@jitar/server-nodejs": "^0.4.0"
             },
             "engines": {
                 "node": ">=18.7"

--- a/packages/jitar/package.json
+++ b/packages/jitar/package.json
@@ -20,8 +20,6 @@
         "release": "npm run clean && npm run build && npm publish"
     },
     "dependencies": {
-        "@jitar/runtime": "^0.4.0",
-        "@jitar/server-nodejs": "^0.4.0",
         "express": "^4.18.2",
         "express-http-proxy": "^1.6.3",
         "fs-extra": "^11.1.1",
@@ -30,6 +28,10 @@
         "tslog": "^4.8.2",
         "yargs": "^17.7.2",
         "zod": "^3.21.4"
+    },
+    "devDependencies": {
+        "@jitar/runtime": "^0.4.0",
+        "@jitar/server-nodejs": "^0.4.0"
     },
     "engines": {
         "node": ">=18.7"


### PR DESCRIPTION
Fixes #314 

Changes proposed in this pull request:
- Moved the dependencies on our own packages to devDependencies
- Installation size reduced, as not all @jitar packages are installed

@MaskingTechnology/jitar
