### PR TITLE
285 configure health checks via the service definition

### DIFF
--- a/documentation/docs/deploy/environments.md
+++ b/documentation/docs/deploy/environments.md
@@ -33,13 +33,14 @@ And a standalone starter script that adds all middleware used by the application
 
 ```ts
 // src/standalone.ts
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-const server = await startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
 server.addMiddleware(/* first */);
 server.addMiddleware(/* second */);
+server.start();
 /* … */
 ```
 

--- a/documentation/docs/deploy/health-checks.md
+++ b/documentation/docs/deploy/health-checks.md
@@ -39,18 +39,33 @@ The health check interface requires you to implement the `timeout` getter. If a 
 
 ## Adding health checks
 
-A health check needs to be added to the service that has the connection to the database. For this we need to create a custom starter, just like we do for [adding middleware](../develop/middleware#adding-middleware).
+A health check needs to be added to the service that has the connection to the database. We need to update the starter script to register the health check at the server level, and use configuration to determine the actual instance that will get the health check.
 
 ```ts
-// node.ts
-import { startServer } from 'jitar';
+// jitar.ts
+import { buildServer } from 'jitar';
 
 import DatabaseHealthCheck from './health/DatabaseHealthCheck.js';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-const server = await startServer(moduleImporter);
-server.addHealthCheck('database', new DatabaseHealthCheck());
+const server = await buildServer(moduleImporter);
+server.registerHealthCheck('database', new DatabaseHealthCheck());
+server.start();
+```
+
+The configuration of the gateway needs to be updated to include the health check.
+
+```json
+// services/gateway.json
+{
+    "url": "http://localhost:3000",
+    "healthChecks": ["database"],
+    "gateway":
+    {
+        // ...
+    }
+}
 ```
 
 Once added, the gateway will trigger the check automatically. You can also check yourself using the health API. More information on this can be found in the [MONITOR section](../monitor/health).

--- a/documentation/docs/develop/middleware.md
+++ b/documentation/docs/develop/middleware.md
@@ -51,13 +51,14 @@ Middleware needs to be registered at the start of a Jitar server.
 
 ```ts
 // src/standalone.ts
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 import MyMiddleware from './MyMiddleware';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-const server = await startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
 server.addMiddleware(new LoggingMiddleware());
+server.start();
 ```
 
 It's only useful to add middleware to a node, gateway, proxy and standalone service because they are actively involved with the communication system. Adding middleware to a repository service won't result in an error, but doesn't have any effect either.

--- a/documentation/docs/integrate/rpc-api.md
+++ b/documentation/docs/integrate/rpc-api.md
@@ -321,7 +321,7 @@ export default PersonNotFound extends NotFound
 Depending on the external application, CORS headers might be required to allow the connection. Jitar provides a CORS middleware implementation that you can use out-of-the-box.
 
 ```ts
-import { startServer, CorsMiddleware } from 'jitar';
+import { buildServer, CorsMiddleware } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
@@ -329,8 +329,9 @@ const origin = 'https://example.com';
 const headers = 'X-Custom-Header-1, X-Custom-Header-2';
 const cors = new CorsMiddleware(origin, headers);
 
-const server = await startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
 server.addMiddleware(cors);
+server.start();
 ```
 
 Only a single origin is supported. If you need a multi-domain setup you can provide a * (wildcard). The allowed headers are specified in a comma-separated list. You can also use a * (wildcard) to allow all. By default the CORS middleware will use a wildcard for the domain and headers if not specified.

--- a/documentation/docs/introduction/quick-start.md
+++ b/documentation/docs/introduction/quick-start.md
@@ -116,11 +116,12 @@ The configuration needs to be supplied when starting a Jitar instance. To start 
 
 ```ts
 //src/jitar.ts
-import { startServer } from 'jitar'
+import { buildServer } from 'jitar';
 
-const moduleImporter = async (specifier: string) => import(specifier)
+const moduleImporter = async (specifier: string) => import(specifier);
 
-startServer(moduleImporter)
+const server = buildServer(moduleImporter);
+server.start();
 ```
 
 This script can be extended by adding [middleware](../develop/middleware.md) and [health checks](../deploy/health-checks.md) to the server when needed.

--- a/examples/apps/contact-list/src/jitar.ts
+++ b/examples/apps/contact-list/src/jitar.ts
@@ -1,6 +1,7 @@
 
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
+server.start();

--- a/examples/concepts/access-protection/src/jitar.ts
+++ b/examples/concepts/access-protection/src/jitar.ts
@@ -1,6 +1,7 @@
 
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
+server.start();

--- a/examples/concepts/cors/src/jitar.ts
+++ b/examples/concepts/cors/src/jitar.ts
@@ -1,7 +1,10 @@
 
-import { startServer, CorsMiddleware } from 'jitar';
+import { buildServer, CorsMiddleware } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-const server = await startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
+
 server.addMiddleware(new CorsMiddleware('http://localhost:8080'));
+
+server.start();

--- a/examples/concepts/data-transportation/src/jitar.ts
+++ b/examples/concepts/data-transportation/src/jitar.ts
@@ -1,6 +1,7 @@
 
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
+server.start();

--- a/examples/concepts/error-handling/src/jitar.ts
+++ b/examples/concepts/error-handling/src/jitar.ts
@@ -1,6 +1,7 @@
 
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
+server.start();

--- a/examples/concepts/health-checks/services/standalone.json
+++ b/examples/concepts/health-checks/services/standalone.json
@@ -1,5 +1,6 @@
 {
     "url": "http://127.0.0.1:3000",
+    "healthChecks": ["database"],
     "standalone":
     {
         

--- a/examples/concepts/health-checks/src/jitar.ts
+++ b/examples/concepts/health-checks/src/jitar.ts
@@ -1,9 +1,10 @@
 
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 import DatabaseHealthCheck from './DatabaseHealthCheck.js';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-const server = await startServer(moduleImporter);
-server.addHealthCheck('database', new DatabaseHealthCheck());
+const server = await buildServer(moduleImporter);
+server.registerHealthCheck('database', new DatabaseHealthCheck());
+server.start();

--- a/examples/concepts/hello-world/src/jitar.ts
+++ b/examples/concepts/hello-world/src/jitar.ts
@@ -1,6 +1,7 @@
 
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
+server.start();

--- a/examples/concepts/load-balancing/src/jitar.ts
+++ b/examples/concepts/load-balancing/src/jitar.ts
@@ -1,6 +1,7 @@
 
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
+server.start();

--- a/examples/concepts/middleware/src/jitar.ts
+++ b/examples/concepts/middleware/src/jitar.ts
@@ -1,9 +1,10 @@
 
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 import LoggingMiddleware from './LoggingMiddleware.js';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-const server = await startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
 server.addMiddleware(new LoggingMiddleware());
+server.start();

--- a/examples/concepts/multi-version/src/jitar.ts
+++ b/examples/concepts/multi-version/src/jitar.ts
@@ -1,6 +1,7 @@
 
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
+server.start();

--- a/examples/concepts/node-client/src/jitar.ts
+++ b/examples/concepts/node-client/src/jitar.ts
@@ -1,6 +1,7 @@
 
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
+server.start();

--- a/examples/concepts/segmentation/src/jitar.ts
+++ b/examples/concepts/segmentation/src/jitar.ts
@@ -1,6 +1,7 @@
 
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
+server.start();

--- a/migrations/migrate-from-0.4.0-to-0.4.1.md
+++ b/migrations/migrate-from-0.4.0-to-0.4.1.md
@@ -1,5 +1,13 @@
 # Migrate from 0.4.0 to 0.4.1
 
+## Breaking changes
+
+The configuration of the server has been updated. In 0.4.1 the server needs to be build first, and then manually started using the server.start() function. This allows for more flexibility in the setup of the health checks.
+
+Previously, the starter script needed to be unique for each instance if there where different health checks required. Now the starter script can be the same for all instances, and the health checks can be configured in the configuration file. More information can be found in the [health check](https://docs.jitar.dev/deploy/health-checks.html) documentation.
+
+## Health check timeout
+
 The health check interface is updated and now has a getter for a `timeout` value. Each health check must implement the timeout getter, even if the health check doesn't need a timeout. We want the absence of a timeout value to be a well considered choice.
 
 To define a health check without a timeout value, make the getter return `undefined`. Otherwise set a value in milliseconds to consider the health check timed out and unhealthy. You can find an example in the [health check interface](https://docs.jitar.dev/deploy/health-checks.html) documentation.

--- a/packages/create-jitar/templates/jitar-only/src/jitar.ts
+++ b/packages/create-jitar/templates/jitar-only/src/jitar.ts
@@ -1,6 +1,7 @@
 
-import { startServer } from 'jitar';
+import { buildServer } from 'jitar';
 
 const moduleImporter = async (specifier: string) => import(specifier);
 
-startServer(moduleImporter);
+const server = await buildServer(moduleImporter);
+server.start();

--- a/packages/create-jitar/templates/lit/src/jitar.ts
+++ b/packages/create-jitar/templates/lit/src/jitar.ts
@@ -1,5 +1,6 @@
-import { startServer } from 'jitar'
+import { buildServer } from 'jitar'
 
 const moduleImporter = async (specifier: string) => import(specifier)
 
-startServer(moduleImporter)
+const server = await buildServer(moduleImporter);
+server.start();

--- a/packages/create-jitar/templates/react/src/jitar.ts
+++ b/packages/create-jitar/templates/react/src/jitar.ts
@@ -1,5 +1,6 @@
-import { startServer } from 'jitar'
+import { buildServer } from 'jitar'
 
 const moduleImporter = async (specifier: string) => import(specifier)
 
-startServer(moduleImporter)
+const server = await buildServer(moduleImporter);
+server.start();

--- a/packages/create-jitar/templates/solid/src/jitar.ts
+++ b/packages/create-jitar/templates/solid/src/jitar.ts
@@ -1,5 +1,6 @@
-import { startServer } from 'jitar'
+import { buildServer } from 'jitar'
 
 const moduleImporter = async (specifier: string) => import(specifier)
 
-startServer(moduleImporter)
+const server = await buildServer(moduleImporter);
+server.start();

--- a/packages/create-jitar/templates/svelte/src/jitar.ts
+++ b/packages/create-jitar/templates/svelte/src/jitar.ts
@@ -1,5 +1,6 @@
-import { startServer } from 'jitar'
+import { buildServer } from 'jitar'
 
 const moduleImporter = async (specifier: string) => import(specifier)
 
-startServer(moduleImporter)
+const server = await buildServer(moduleImporter);
+server.start();

--- a/packages/create-jitar/templates/vue/src/jitar.ts
+++ b/packages/create-jitar/templates/vue/src/jitar.ts
@@ -1,5 +1,6 @@
-import { startServer } from 'jitar'
+import { buildServer } from 'jitar'
 
 const moduleImporter = async (specifier: string) => import(specifier)
 
-startServer(moduleImporter)
+const server = await buildServer(moduleImporter);
+server.start();

--- a/packages/jitar/src/server.ts
+++ b/packages/jitar/src/server.ts
@@ -1,2 +1,2 @@
 
-export { startServer, CorsMiddleware } from '@jitar/server-nodejs';
+export { buildServer, CorsMiddleware } from '@jitar/server-nodejs';

--- a/packages/server-nodejs/src/JitarServer.ts
+++ b/packages/server-nodejs/src/JitarServer.ts
@@ -47,7 +47,7 @@ export default class JitarServer
 
     #options: ServerOptions;
     #configuration: RuntimeConfiguration;
-    #logger: Logger;
+    #logger: Logger<unknown>;
 
     #registeredHealthChecks: Map<string, HealthCheck> = new Map();
 
@@ -70,18 +70,14 @@ export default class JitarServer
     async build(): Promise<void>
     {
         this.#runtime = await RuntimeConfigurator.configure(this.#configuration);
-
-
         this.#addControllers(this.#configuration, this.#runtime, this.#logger);
-
-
     }
 
     async start(): Promise<void>
     {
         console.log(STARTUP_MESSAGE);
 
-        const url = new URL(configuration.url ?? RuntimeDefaults.URL);
+        const url = new URL(this.#configuration.url ?? RuntimeDefaults.URL);
 
         this.#addHealthChecks();
 

--- a/packages/server-nodejs/src/configuration/RuntimeConfiguration.ts
+++ b/packages/server-nodejs/src/configuration/RuntimeConfiguration.ts
@@ -10,6 +10,7 @@ import StandaloneConfiguration, { standaloneSchema } from './StandaloneConfigura
 export const runtimeSchema = z
     .object({
         url: z.string().optional(),
+        healthChecks: z.array(z.string()).optional(),
         standalone: standaloneSchema.optional(),
         repository: repositorySchema.optional(),
         gateway: gatewaySchema.optional(),
@@ -17,20 +18,22 @@ export const runtimeSchema = z
         proxy: proxySchema.optional(),
     })
     .strict()
-    .transform((value) => new RuntimeConfiguration(value.url, value.standalone, value.repository, value.gateway, value.node, value.proxy));
+    .transform((value) => new RuntimeConfiguration(value.url, value.healthChecks, value.standalone, value.repository, value.gateway, value.node, value.proxy));
 
 export default class RuntimeConfiguration
 {
     #url?: string;
+    #healthChecks?: string[];
     #standalone?: StandaloneConfiguration;
     #repository?: RepositoryConfiguration;
     #gateway?: GatewayConfiguration;
     #node?: NodeConfiguration;
     #proxy?: ProxyConfiguration;
 
-    constructor(url?: string, standalone?: StandaloneConfiguration, repository?: RepositoryConfiguration, gateway?: GatewayConfiguration, node?: NodeConfiguration, proxy?: ProxyConfiguration)
+    constructor(url?: string, healthChecks?: string[], standalone?: StandaloneConfiguration, repository?: RepositoryConfiguration, gateway?: GatewayConfiguration, node?: NodeConfiguration, proxy?: ProxyConfiguration)
     {
         this.#url = url;
+        this.#healthChecks = healthChecks;
         this.#standalone = standalone;
         this.#repository = repository;
         this.#gateway = gateway;
@@ -39,6 +42,8 @@ export default class RuntimeConfiguration
     }
 
     get url() { return this.#url; }
+
+    get healthChecks() { return this.#healthChecks; }
 
     get standalone() { return this.#standalone; }
 

--- a/packages/server-nodejs/src/errors/DuplicateHealthCheck.ts
+++ b/packages/server-nodejs/src/errors/DuplicateHealthCheck.ts
@@ -1,0 +1,8 @@
+
+export default class DuplicateHealthCheck extends Error
+{
+    constructor(name: string)
+    {
+        super(`Health check '${name}' is already registered.`);
+    }
+}

--- a/packages/server-nodejs/src/errors/UnknownHealthCheck.ts
+++ b/packages/server-nodejs/src/errors/UnknownHealthCheck.ts
@@ -1,0 +1,8 @@
+
+export default class UnknownHealthCheck extends Error
+{
+    constructor(name: string)
+    {
+        super(`Health check '${name}' is not registered.`);
+    }
+}

--- a/packages/server-nodejs/src/server.ts
+++ b/packages/server-nodejs/src/server.ts
@@ -3,13 +3,13 @@ import { ModuleImporter, ModuleLoader } from '@jitar/runtime';
 
 import JitarServer from './JitarServer.js';
 
-export async function startServer(moduleImporter: ModuleImporter): Promise<JitarServer>
+export async function buildServer(moduleImporter: ModuleImporter): Promise<JitarServer>
 {
     ModuleLoader.setImporter(moduleImporter);
 
     const server = new JitarServer();
 
-    await server.start();
+    await server.build();
 
     return server;
 }


### PR DESCRIPTION
Fixes #285 

Changes proposed in this pull request:
- register health checks to the server instance
- add health checks based on configuration
- split the build and start of the server in two separate steps

@MaskingTechnology/jitar
