### PR TITLE
chore(build): update linter to eliminate returns of await in async functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "rules":
     {
         "@typescript-eslint/ban-types": "off",
+        "no-return-await": "error",
         "semi": ["error", "always"],
         "eol-last": ["error", "always"],
         "brace-style": ["error", "allman", { "allowSingleLine": true }],

--- a/packages/caching/src/building/ApplicationCacheWriter.ts
+++ b/packages/caching/src/building/ApplicationCacheWriter.ts
@@ -28,11 +28,11 @@ export default class ApplicationCacheWriter
 
     async #writeSegmentCache(segments: SegmentCache[]): Promise<void>
     {
-        return Promise.all(segments.map(async (segment) => await this.#segmentWriter.write(segment))).then(() => undefined);
+        return Promise.all(segments.map(async (segment) => this.#segmentWriter.write(segment))).then(() => undefined);
     }
 
     async #writeModuleCache(modules: ModuleCache[]): Promise<void>
     {
-        return Promise.all(modules.map(async (module) => await this.#moduleWriter.write(module))).then(() => undefined);
+        return Promise.all(modules.map(async (module) => this.#moduleWriter.write(module))).then(() => undefined);
     }
 }

--- a/packages/caching/src/building/ApplicationReader.ts
+++ b/packages/caching/src/building/ApplicationReader.ts
@@ -29,11 +29,11 @@ export default class ApplicationReader
 
     async #readSegments(segmentFiles: string[]): Promise<Segment[]>
     {
-        return Promise.all(segmentFiles.map(async (segmentFile) => await this.#segmentReader.read(segmentFile)));
+        return Promise.all(segmentFiles.map(async (segmentFile) => this.#segmentReader.read(segmentFile)));
     }
 
     async #readModules(moduleFiles: string[]): Promise<Module[]>
     {
-        return Promise.all(moduleFiles.map(async (moduleFile) => await this.#moduleReader.read(moduleFile)));
+        return Promise.all(moduleFiles.map(async (moduleFile) => this.#moduleReader.read(moduleFile)));
     }
 }

--- a/packages/plugin-vite/src/index.ts
+++ b/packages/plugin-vite/src/index.ts
@@ -122,7 +122,7 @@ export default function viteJitar(sourcePath: string, jitarPath: string, jitarUr
                 return code;
             }
 
-            return await createImportCode(code, id, jitarFullPath, jitarPath);
+            return createImportCode(code, id, jitarFullPath, jitarPath);
         },
 
         transformIndexHtml(html)

--- a/packages/runtime/src/services/NodeMonitor.ts
+++ b/packages/runtime/src/services/NodeMonitor.ts
@@ -18,7 +18,7 @@ export default class NodeMonitor
 
     start(): void
     {
-        this.#interval = setInterval(async () => await this.#monitor(), this.#frequency);
+        this.#interval = setInterval(async () => this.#monitor(), this.#frequency);
     }
 
     stop(): void
@@ -34,7 +34,7 @@ export default class NodeMonitor
     async #monitor(): Promise<void>
     {
         const nodes = this.#gateway.nodes;
-        const promises = nodes.map(async (node: Node) => await this.#monitorNode(node));
+        const promises = nodes.map(async (node: Node) => this.#monitorNode(node));
 
         await Promise.all(promises);
     }

--- a/packages/runtime/test/services/LocalGateway.spec.ts
+++ b/packages/runtime/test/services/LocalGateway.spec.ts
@@ -69,7 +69,7 @@ describe('services/LocalGateway', () =>
 
         it('should not run a non-existing procedure', async () =>
         {
-            const run = async () => await gateway.run('nonExisting', Version.DEFAULT, new Map(), new Map());
+            const run = async () => gateway.run('nonExisting', Version.DEFAULT, new Map(), new Map());
 
             expect(run).rejects.toEqual(new ProcedureNotFound('nonExisting'));
         });

--- a/packages/runtime/test/services/LocalNode.spec.ts
+++ b/packages/runtime/test/services/LocalNode.spec.ts
@@ -73,7 +73,7 @@ describe('services/LocalNode', () =>
 
         it('should not run a non-existing procedure', async () =>
         {
-            const run = async () => await node.run('nonExisting', Version.DEFAULT, new Map(), new Map());
+            const run = async () => node.run('nonExisting', Version.DEFAULT, new Map(), new Map());
 
             expect(run).rejects.toEqual(new ProcedureNotFound('nonExisting'));
         });

--- a/packages/runtime/test/services/LocalRepository.spec.ts
+++ b/packages/runtime/test/services/LocalRepository.spec.ts
@@ -15,14 +15,14 @@ describe('services/LocalRepository', () =>
     {
         it('should not accept an invalid client id', () =>
         {
-            const run = async () => await repository.loadModule('INVALID', '/some/file');
+            const run = async () => repository.loadModule('INVALID', '/some/file');
 
             expect(run).rejects.toEqual(new InvalidClientId('INVALID'));
         });
 
         it('should not accept an unknown client id', () =>
         {
-            const run = async () => await repository.loadModule('CLIENT_9999', '/some/file');
+            const run = async () => repository.loadModule('CLIENT_9999', '/some/file');
 
             expect(run).rejects.toEqual(new ClientNotFound('CLIENT_9999'));
         });
@@ -57,7 +57,7 @@ describe('services/LocalRepository', () =>
 
         it('should not return a private asset', async () =>
         {
-            const run = async () => await repository.loadAsset('style.css');
+            const run = async () => repository.loadAsset('style.css');
 
             expect(run).rejects.toEqual(new FileNotFound('style.css'));
         });

--- a/packages/runtime/test/services/NodeBalancer.spec.ts
+++ b/packages/runtime/test/services/NodeBalancer.spec.ts
@@ -31,7 +31,7 @@ describe('services/LocalGateway', () =>
     {
         it('should throw a node not available error', async () =>
         {
-            const run = async () => await emptyBalancer.run('nonExisting', Version.DEFAULT, new Map(), new Map());
+            const run = async () => emptyBalancer.run('nonExisting', Version.DEFAULT, new Map(), new Map());
 
             expect(run).rejects.toEqual(new NoNodeAvailable('nonExisting'));
         });

--- a/packages/serialization/src/serializers/ArraySerializer.ts
+++ b/packages/serialization/src/serializers/ArraySerializer.ts
@@ -12,7 +12,7 @@ export default class ArraySerializer extends ValueSerializer
     {
         return value instanceof Array;
     }
-    
+
     async serialize(array: unknown[]): Promise<unknown[]>
     {
         const values: unknown[] = [];
@@ -27,6 +27,6 @@ export default class ArraySerializer extends ValueSerializer
 
     async deserialize(array: unknown[]): Promise<unknown[]>
     {
-        return await Promise.all(array.map(async (value) => await this.deserializeOther(value)));
+        return Promise.all(array.map(async (value) => this.deserializeOther(value)));
     }
 }

--- a/packages/serialization/src/serializers/ClassSerializer.ts
+++ b/packages/serialization/src/serializers/ClassSerializer.ts
@@ -32,7 +32,7 @@ export default class ClassSerializer extends ValueSerializer
     canDeserialize(value: unknown): boolean
     {
         const object = value as SerializedClass;
-        
+
         return object instanceof Object
             && object.serialized === true
             && typeof object.name === 'string'
@@ -74,7 +74,7 @@ export default class ClassSerializer extends ValueSerializer
             const objectValue = model.canRead(name)
                 ? await this.serializeOther((object as FlexObject)[name])
                 : undefined;
-            
+
             args.push(objectValue);
         }
 
@@ -115,7 +115,7 @@ export default class ClassSerializer extends ValueSerializer
             throw new InvalidClass(object.name);
         }
 
-        const args = await Promise.all(object.args.map(async (value) => await this.deserializeOther(value)));
+        const args = await Promise.all(object.args.map(async (value) => this.deserializeOther(value)));
 
         const instance = reflector.createInstance(clazz as Function, args) as SerializableObject;
 

--- a/packages/serialization/src/serializers/SetSerializer.ts
+++ b/packages/serialization/src/serializers/SetSerializer.ts
@@ -16,9 +16,9 @@ export default class SetSerializer extends ValueSerializer
         return set instanceof Object
             && set.serialized === true
             && set.name === 'Set'
-            && set.values instanceof Array; 
+            && set.values instanceof Array;
     }
-    
+
     async serialize(set: Set<unknown>): Promise<SerializedSet>
     {
         const values: unknown[] = [];
@@ -33,7 +33,7 @@ export default class SetSerializer extends ValueSerializer
 
     async deserialize(object: SerializedSet): Promise<Set<unknown>>
     {
-        const values = await Promise.all(object.values.map(async (value: unknown) => await this.deserializeOther(value)));
+        const values = await Promise.all(object.values.map(async (value: unknown) => this.deserializeOther(value)));
 
         return new Set([...values]);
     }

--- a/packages/serialization/test/DefaultClassLoader.spec.ts
+++ b/packages/serialization/test/DefaultClassLoader.spec.ts
@@ -5,11 +5,12 @@ import DefaultClassLoader from '../src/DefaultClassLoader';
 import ClassNotFound from '../src/errors/ClassNotFound';
 import InvalidClass from '../src/errors/InvalidClass';
 
-import { 
-    Person, Customer,
-    personLoadable, customerLoadable, primitiveLoadable,
-    nonexistingLoadable, invalidLoadable
-} from './_fixtures/DefaultClassLoader.fixture';
+import
+    {
+        Person, Customer,
+        personLoadable, customerLoadable, primitiveLoadable,
+        nonexistingLoadable, invalidLoadable
+    } from './_fixtures/DefaultClassLoader.fixture';
 
 const loader = new DefaultClassLoader();
 
@@ -28,21 +29,21 @@ describe('DefaultClassLoader', () =>
 
         it('should not load non-class types', async () =>
         {
-            const loadClass = async () => await loader.loadClass(primitiveLoadable);
+            const loadClass = async () => loader.loadClass(primitiveLoadable);
 
             expect(loadClass).rejects.toStrictEqual(new InvalidClass('primitive'));
         });
 
         it('should not load non-existing classes', async () =>
         {
-            const loadClass = async () => await loader.loadClass(nonexistingLoadable);
+            const loadClass = async () => loader.loadClass(nonexistingLoadable);
 
             expect(loadClass).rejects.toStrictEqual(new ClassNotFound('nonexisting'));
         });
 
         it('should not load from invalid sources', async () =>
         {
-            const loadClass = async () => await loader.loadClass(invalidLoadable);
+            const loadClass = async () => loader.loadClass(invalidLoadable);
 
             expect(loadClass).rejects.toStrictEqual(new ClassNotFound('invalid'));
         });

--- a/packages/serialization/test/Serializer.spec.ts
+++ b/packages/serialization/test/Serializer.spec.ts
@@ -5,10 +5,11 @@ import Serializer from '../src/Serializer';
 import NoSerializerFound from '../src/errors/NoSerializerFound';
 import NoDeserializerFound from '../src/errors/NoDeserializerFound';
 
-import {
-    FirstSerializer, SecondSerializer,
-    NumberSerializer, StringSerializer
-} from './_fixtures/Serializer.fixture';
+import
+    {
+        FirstSerializer, SecondSerializer,
+        NumberSerializer, StringSerializer
+    } from './_fixtures/Serializer.fixture';
 
 const overrideSerializer = new Serializer();
 overrideSerializer.addSerializer(new FirstSerializer());
@@ -40,7 +41,7 @@ describe('Serializer', () =>
 
         it('should throw error when no applicable serializer is found', async () =>
         {
-            const serialize = async () => await typeSerializer.serialize(true);
+            const serialize = async () => typeSerializer.serialize(true);
 
             expect(serialize).rejects.toStrictEqual(new NoSerializerFound('boolean'));
         });
@@ -66,7 +67,7 @@ describe('Serializer', () =>
 
         it('should throw error when no applicable deserializer is found', async () =>
         {
-            const deserialize = async () => await typeSerializer.deserialize(true);
+            const deserialize = async () => typeSerializer.deserialize(true);
 
             expect(deserialize).rejects.toStrictEqual(new NoDeserializerFound('boolean'));
         });

--- a/packages/serialization/test/serializers/ClassSerializer.spec.ts
+++ b/packages/serialization/test/serializers/ClassSerializer.spec.ts
@@ -6,12 +6,13 @@ import InvalidClass from '../../src/errors/InvalidClass';
 
 import ClassSerializer from '../../src/serializers/ClassSerializer';
 
-import {
-    parent, classLoader,
-    dataClass, constructedClass, nestedClass, privateClass,
-    serializedDataClass, serializedConstructedClass, serializedNestedClass, serializedPrivateClass, serializedInvalidClass, serializedUnserializableClass,
-    nonObject, nonClassObject, notSerialized, invalidName, invalidArgs, invalidFields
-} from '../_fixtures/serializers/ClassSerializer.fixture';
+import
+    {
+        parent, classLoader,
+        dataClass, constructedClass, nestedClass, privateClass,
+        serializedDataClass, serializedConstructedClass, serializedNestedClass, serializedPrivateClass, serializedInvalidClass, serializedUnserializableClass,
+        nonObject, nonClassObject, notSerialized, invalidName, invalidArgs, invalidFields
+    } from '../_fixtures/serializers/ClassSerializer.fixture';
 
 const serializer = new ClassSerializer(classLoader);
 serializer.parent = parent;
@@ -31,7 +32,7 @@ describe('serializers/ClassSerializer', () =>
         {
             const supportsNonObject = serializer.canSerialize(nonObject);
             const supportsNonClassObject = serializer.canSerialize(nonClassObject);
-            
+
             expect(supportsNonObject).toBeFalsy();
             expect(supportsNonClassObject).toBeFalsy();
         });
@@ -96,14 +97,14 @@ describe('serializers/ClassSerializer', () =>
 
         it('should not deserialize invalid objects', async () =>
         {
-            const deserialize = async () => await serializer.deserialize(serializedInvalidClass);
+            const deserialize = async () => serializer.deserialize(serializedInvalidClass);
 
             expect(deserialize).rejects.toStrictEqual(new ClassNotFound('Invalid'));
         });
 
         it('should not deserialize non-function instances', async () =>
         {
-            const deserialize = async () => await serializer.deserialize(serializedUnserializableClass);
+            const deserialize = async () => serializer.deserialize(serializedUnserializableClass);
 
             expect(deserialize).rejects.toStrictEqual(new InvalidClass('Infinity'));
         });

--- a/packages/serialization/test/serializers/DateSerializer.spec.ts
+++ b/packages/serialization/test/serializers/DateSerializer.spec.ts
@@ -4,11 +4,12 @@ import { describe, expect, it } from 'vitest';
 import DateSerializer from '../../src/serializers/DateSerializer';
 import InvalidDateString from '../../src/serializers/errors/InvalidDateString';
 
-import {
-    fixedDate,
-    serializedFixedDate,
-    nonObject, nonDate, notSerialized, invalidName, invalidDateValue, invalidDateString
-} from '../_fixtures/serializers/DateSerializer.fixture';
+import
+    {
+        fixedDate,
+        serializedFixedDate,
+        nonObject, nonDate, notSerialized, invalidName, invalidDateValue, invalidDateString
+    } from '../_fixtures/serializers/DateSerializer.fixture';
 
 const serializer = new DateSerializer();
 
@@ -77,7 +78,7 @@ describe('serializers/DateSerializer', () =>
 
         it('should not deserialize a date with an invalid date string', async () =>
         {
-            const deserialize = async () => await serializer.deserialize(invalidDateString);
+            const deserialize = async () => serializer.deserialize(invalidDateString);
 
             expect(deserialize).rejects.toStrictEqual(new InvalidDateString('hello'));
         });

--- a/packages/serialization/test/serializers/UrlSerializer.spec.ts
+++ b/packages/serialization/test/serializers/UrlSerializer.spec.ts
@@ -78,7 +78,7 @@ describe('serializers/UrlSerializer', () =>
 
         it('should not deserialize an url with an invalid url string', async () =>
         {
-            const deserialize = async () => await serializer.deserialize(invalidUrlString);
+            const deserialize = async () => serializer.deserialize(invalidUrlString);
 
             expect(deserialize).rejects.toStrictEqual(new InvalidUrlString('example'));
         });

--- a/packages/server-nodejs/src/utils/LocalFileManager.ts
+++ b/packages/server-nodejs/src/utils/LocalFileManager.ts
@@ -90,7 +90,7 @@ export default class LocalFileManager implements FileManager
     {
         const location = this.getAbsoluteLocation('./');
 
-        return await glob(`${location}/${pattern}`);
+        return glob(`${location}/${pattern}`);
     }
 
     async getNodeSegmentFiles(): Promise<string[]>


### PR DESCRIPTION
Fixes #282 

Changes proposed in this pull request:
- updated linter config to detect return await
- removed all unnecessary await statements

@MaskingTechnology/jitar
