### PR TITLE
bug(server): serialization control at the gateway

### DIFF
--- a/examples/concepts/data-transportation/requests.http
+++ b/examples/concepts/data-transportation/requests.http
@@ -1,4 +1,12 @@
 
 // Register John Doe for an account
+// This will return the registration information as a string
 
 GET http://localhost:3000/rpc/helpdesk/register?firstName=John&lastName=Doe HTTP/1.1
+
+###
+
+// Create an account for John Doe
+// This will return the serialized account object
+
+GET http://localhost:3000/rpc/account/createAccount?firstName=John&lastName=Doe&serialize=true HTTP/1.1 

--- a/packages/runtime/src/services/RemoteGateway.ts
+++ b/packages/runtime/src/services/RemoteGateway.ts
@@ -15,7 +15,7 @@ export default class RemoteGateway extends Gateway
     {
         super(url);
 
-        this.#remote = new Remote(url, true);
+        this.#remote = new Remote(url);
     }
 
     getProcedureNames(): string[]

--- a/packages/runtime/src/services/RemoteNode.ts
+++ b/packages/runtime/src/services/RemoteNode.ts
@@ -13,7 +13,7 @@ export default class RemoteNode extends Node
     {
         super(url);
 
-        this.#remote = new Remote(url, false);
+        this.#remote = new Remote(url);
 
         this.registerProcedures(procedureNames);
     }

--- a/packages/runtime/src/services/RemoteRepository.ts
+++ b/packages/runtime/src/services/RemoteRepository.ts
@@ -13,7 +13,7 @@ export default class RemoteRepository extends Repository
     {
         super(url);
 
-        this.#remote = new Remote(url, true);
+        this.#remote = new Remote(url);
     }
 
     registerClient(segmentFiles: string[]): Promise<string>

--- a/packages/server-nodejs/src/JitarServer.ts
+++ b/packages/server-nodejs/src/JitarServer.ts
@@ -170,7 +170,7 @@ export default class JitarServer
         new JitarController(this.#app);
         new ModulesController(this.#app, proxy, this.#serializer, this.#logger);
         new ProceduresController(this.#app, proxy, this.#logger);
-        new RPCController(this.#app, proxy, this.#serializer, true, this.#logger);
+        new RPCController(this.#app, proxy, this.#serializer, this.#logger);
         new AssetsController(this.#app, proxy, index, this.#logger);
     }
 
@@ -185,14 +185,14 @@ export default class JitarServer
     {
         new NodesController(this.#app, gateway, this.#logger);
         new ProceduresController(this.#app, gateway, this.#logger);
-        new RPCController(this.#app, gateway, this.#serializer, false, this.#logger);
+        new RPCController(this.#app, gateway, this.#serializer, this.#logger);
     }
 
     #addNodeControllers(node: LocalNode): void
     {
         new HealthController(this.#app, node, this.#logger);
         new ProceduresController(this.#app, node, this.#logger);
-        new RPCController(this.#app, node, this.#serializer, true, this.#logger);
+        new RPCController(this.#app, node, this.#serializer, this.#logger);
     }
 
     #addProxyControllers(proxy: Proxy): void


### PR DESCRIPTION
Fixes #323 

Changes proposed in this pull request:
- Removed the serialization control from the runtime (is now always on)
- Simplified the serialization control in the server (only listens to the query param)

@MaskingTechnology/jitar
