### PR TITLE
chore(build): add node v21 into pipeline

### DIFF
--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 19.x, 20.x]
+        node-version: [18.x, 19.x, 20.x, 21.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #370 

Changes proposed in this pull request:
- new version of node added to ci

@MaskingTechnology/jitar
