### PR TITLE
fix(reflection): non-reserved keywords as identifiers

### DIFF
--- a/packages/reflection/src/parser/definitions/Keyword.ts
+++ b/packages/reflection/src/parser/definitions/Keyword.ts
@@ -37,4 +37,13 @@ function isDeclaration(value: string): boolean
         || value === Keyword.VAR;
 }
 
-export { Keyword, isKeyword, isDeclaration };
+function isNotReserved(value: string): boolean
+{
+    return value === Keyword.AS
+        || value === Keyword.ASYNC
+        || value === Keyword.FROM
+        || value === Keyword.GET
+        || value === Keyword.SET;
+}
+
+export { Keyword, isKeyword, isDeclaration, isNotReserved };

--- a/packages/reflection/test/_fixtures/parser/Parser.fixture.ts
+++ b/packages/reflection/test/_fixtures/parser/Parser.fixture.ts
@@ -49,7 +49,9 @@ const DECLARATIONS =
     OBJECT: "const object = { key1: 'value1', key2: 'value2' };",
     REGEX: "const regex = /regex/g;",
     DESTRUCTURING_ARRAY: "const [value1, value2 = true] = array;",
-    DESTRUCTURING_OBJECT: "const {key1, key2 = false} = object;"
+    DESTRUCTURING_OBJECT: "const {key1, key2 = false} = object;",
+    KEYWORD_AS_NAME: "const as = 'value';",
+    KEYWORD_AS_VALUE: "const alias = as;"
 };
 
 const FUNCTIONS =
@@ -74,6 +76,7 @@ const FUNCTIONS =
     DESTRUCTURING_REST_PARAMETERS: "function name({ param1, param2 }, [ param3, ...param4 ]) {}",
     SIMPLE_BODY: "function name() { return 'value'; }",
     BLOCK_BODY: "function name() { if (true) { return 'value'; } }",
+    KEYWORD_AS_NAME: "function as() {}"
 };
 
 const CLASSES =
@@ -157,6 +160,13 @@ export class Person
 }
 
 const peter = new Person(name, 42);
+
+async function async() { }
+const a = async;
+const b = async () => {};
+
+const as = 12;
+export { as as hi };
 
 export { name, peter };
 `,

--- a/packages/reflection/test/parser/Parser.spec.ts
+++ b/packages/reflection/test/parser/Parser.spec.ts
@@ -414,6 +414,24 @@ describe('parser/Parser', () =>
             expect(secondMember.value).toBeInstanceOf(ReflectionExpression);
             expect(secondMember.value?.definition).toBe('false');
         });
+
+        it('should parse a declaration with a non reserved keyword as name', () =>
+        {
+            const declaration = parser.parseDeclaration(DECLARATIONS.KEYWORD_AS_NAME);
+
+            expect(declaration.name).toBe('as');
+            expect(declaration.value).toBeInstanceOf(ReflectionExpression);
+            expect(declaration.value?.definition).toBe("'value'");
+        });
+
+        it('should parse a declaration that refers to a non reserved keyword as value', () =>
+        {
+            const declaration = parser.parseDeclaration(DECLARATIONS.KEYWORD_AS_VALUE);
+
+            expect(declaration.name).toBe('alias');
+            expect(declaration.value).toBeInstanceOf(ReflectionExpression);
+            expect(declaration.value?.definition).toBe('as');
+        });
     });
 
     describe('.parseFunction(code)', () =>
@@ -738,6 +756,17 @@ describe('parser/Parser', () =>
             const parameters = funktion.parameters;
             expect(parameters.length).toBe(0);
         });
+
+        it('should parse function with a non reserved keyword as name', () =>
+        {
+            const funktion = parser.parseFunction(FUNCTIONS.KEYWORD_AS_NAME);
+            expect(funktion.name).toBe('as');
+            expect(funktion.isAsync).toBe(false);
+            expect(funktion.body).toBe("{ }");
+
+            const parameters = funktion.parameters;
+            expect(parameters.length).toBe(0);
+        });
     });
 
     describe('.parseClass(code)', () =>
@@ -918,19 +947,19 @@ describe('parser/Parser', () =>
             const module = parser.parse(MODULES.TERMINATED);
             
             const members = module.members;
-            expect(members.length).toBe(9);
+            expect(members.length).toBe(14);
 
             const imports = module.imports;
             expect(imports.length).toBe(2);
 
             const exports = module.exports;
-            expect(exports.length).toBe(3);
+            expect(exports.length).toBe(4);
 
             const declarations = module.declarations;
-            expect(declarations.length).toBe(2);
+            expect(declarations.length).toBe(4);
 
             const functions = module.functions;
-            expect(functions.length).toBe(1);
+            expect(functions.length).toBe(3);
 
             const classes = module.classes;
             expect(classes.length).toBe(1);


### PR DESCRIPTION
Fixes #427 

Changes proposed in this pull request:
- Added support for non-reserved keywords as identifiers

@MaskingTechnology/jitar
