### PR TITLE
#436: Mapped remote response headers

### DIFF
--- a/packages/runtime/src/models/Request.ts
+++ b/packages/runtime/src/models/Request.ts
@@ -46,16 +46,16 @@ export default class Request
 
     setHeader(name: string, value: string): void
     {
-        this.#headers.set(name, value);
+        this.#headers.set(name.toLowerCase(), value);
     }
 
     getHeader(name: string): string | undefined
     {
-        return this.#headers.get(name);
+        return this.#headers.get(name.toLowerCase());
     }
 
     removeHeader(name: string): void
     {
-        this.#headers.delete(name);
+        this.#headers.delete(name.toLowerCase());
     }
 }

--- a/packages/runtime/src/models/Response.ts
+++ b/packages/runtime/src/models/Response.ts
@@ -23,16 +23,16 @@ export default class Response
     
     setHeader(name: string, value: string): void
     {
-        this.#headers.set(name, value);
+        this.#headers.set(name.toLowerCase(), value);
     }
 
     getHeader(name: string): string | undefined
     {
-        return this.#headers.get(name);
+        return this.#headers.get(name.toLowerCase());
     }
 
     removeHeader(name: string): void
     {
-        this.#headers.delete(name);
+        this.#headers.delete(name.toLowerCase());
     }
 }

--- a/packages/runtime/src/services/Remote.ts
+++ b/packages/runtime/src/services/Remote.ts
@@ -110,8 +110,9 @@ export default class Remote
 
         const response = await this.#callRemote(url, options, 200);
         const result = await this.#createResponseResult(response);
+        const headers = this.#createResponseHeaders(response);
 
-        return new ResultResponse(result);
+        return new ResultResponse(result, headers);
     }
 
     async #callRemote(url: string, options: object, expectedStatus: number): Promise<Response>
@@ -150,5 +151,17 @@ export default class Remote
         }
 
         return response.text();
+    }
+
+    #createResponseHeaders(response: Response): Map<string, string>
+    {
+        const headers = new Map();
+
+        for (const [name, value] of response.headers)
+        {
+            headers.set(name, value);
+        }
+
+        return headers;
     }
 }


### PR DESCRIPTION
Fixes #436 

Changes proposed in this pull request:
- Mapped remote response headers
- Always using lower-cased headers

@MaskingTechnology/jitar
