### PR TITLE
fix(runtime): fixed incorrect parsing of return values

### DIFF
--- a/examples/concepts/access-protection/requests.http
+++ b/examples/concepts/access-protection/requests.http
@@ -1,18 +1,33 @@
 
 // Run the public function (succeeds)
 
-GET http://localhost:3000/rpc/web/guessSecret?secret=123
+POST http://localhost:3000/rpc/web/guessSecret HTTP/1.1
+content-type: application/json
+
+{
+    "secret": 123
+}
 
 ###
 
 // Run the protected function with key (succeeds)
-GET http://localhost:3000/rpc/game/checkSecret?secret=123 HTTP/1.1
+POST http://localhost:3000/rpc/game/checkSecret HTTP/1.1
 X-Jitar-Trust-Key: VERY_SECRET_KEY
+content-type: application/json
+
+{
+    "secret": 123
+}
 
 ###
 
 // Run the protected function without key (fails -> 401)
-GET http://localhost:3000/rpc/game/checkSecret?secret=123 HTTP/1.1
+POST http://localhost:3000/rpc/game/checkSecret HTTP/1.1
+content-type: application/json
+
+{
+    "secret": 123
+}
 
 ###
 

--- a/examples/concepts/access-protection/src/game/checkSecret.ts
+++ b/examples/concepts/access-protection/src/game/checkSecret.ts
@@ -1,7 +1,7 @@
 
 import getSecret from './getSecret';
 
-export default async function checkSecret(secret: string): Promise<boolean>
+export default async function checkSecret(secret: number): Promise<boolean>
 {
     return secret === await getSecret();
 }

--- a/examples/concepts/access-protection/src/game/getSecret.ts
+++ b/examples/concepts/access-protection/src/game/getSecret.ts
@@ -3,7 +3,7 @@ const SECRET = Math.round(Math.random() * 1000);
 
 console.log('SECRET:', SECRET);
 
-export default async function getSecret(): Promise<string>
+export default async function getSecret(): Promise<number>
 {
-    return SECRET.toString();
+    return SECRET;
 }

--- a/examples/concepts/access-protection/src/web/guessSecret.ts
+++ b/examples/concepts/access-protection/src/web/guessSecret.ts
@@ -1,11 +1,9 @@
 
 import checkSecret from '../game/checkSecret';
 
-export default async function guessSecret(secret: string): Promise<string>
+export default async function guessSecret(secret: number): Promise<string>
 {
-    const number = Number(secret);
-
-    const isGuessed = await checkSecret(number);
+    const isGuessed = await checkSecret(secret);
 
     return isGuessed ? 'Congratulations!' : 'Sorry, try again!';
 }

--- a/examples/concepts/access-protection/src/web/guessSecret.ts
+++ b/examples/concepts/access-protection/src/web/guessSecret.ts
@@ -3,7 +3,9 @@ import checkSecret from '../game/checkSecret';
 
 export default async function guessSecret(secret: string): Promise<string>
 {
-    const guessed = await checkSecret(secret);
+    const number = Number(secret);
 
-    return guessed ? 'Congratulations!' : 'Sorry, try again!';
+    const isGuessed = await checkSecret(number);
+
+    return isGuessed ? 'Congratulations!' : 'Sorry, try again!';
 }

--- a/packages/runtime/src/services/Remote.ts
+++ b/packages/runtime/src/services/Remote.ts
@@ -142,7 +142,7 @@ export default class Remote
         return this.#serializer.deserialize(result);
     }
 
-    #getResponseResult(response: Response): Promise<unknown>
+    async #getResponseResult(response: Response): Promise<unknown>
     {
         const contentType = response.headers.get('Content-Type');
 
@@ -151,7 +151,19 @@ export default class Remote
             return response.json();
         }
 
-        return response.text();
+        const content = await response.text();
+
+        if (contentType !== null && contentType.includes('boolean'))
+        {
+            return content === 'true';
+        }
+
+        if (contentType !== null && contentType.includes('number'))
+        {
+            return Number(content);
+        }
+
+        return content;
     }
 
     #createResponseHeaders(response: Response): Map<string, string>

--- a/packages/runtime/test/_fixtures/services/Remote.fixture.ts
+++ b/packages/runtime/test/_fixtures/services/Remote.fixture.ts
@@ -1,6 +1,10 @@
 
 import Request from '../../../src/models/Request';
 import Version from '../../../src/models/Version';
+import Remote from '../../../src/services/Remote';
+
+const remote = new Remote('http://localhost:3000');
+const CONTENT_TYPE = 'Content-Type';
 
 const BOOLEAN_REQUEST = new Request('game/checkSecret', Version.DEFAULT, new Map(), new Map());
 const NUMBER_REQUEST = new Request('game/getSecret', Version.DEFAULT, new Map(), new Map());
@@ -35,4 +39,4 @@ function customFetch(input: URL | RequestInfo, options: RequestInit | undefined)
 
 globalThis.fetch = customFetch;
 
-export { REQUESTS };
+export { REQUESTS, remote, CONTENT_TYPE };

--- a/packages/runtime/test/_fixtures/services/Remote.fixture.ts
+++ b/packages/runtime/test/_fixtures/services/Remote.fixture.ts
@@ -1,0 +1,38 @@
+
+import Request from '../../../src/models/Request';
+import Version from '../../../src/models/Version';
+
+const BOOLEAN_REQUEST = new Request('game/checkSecret', Version.DEFAULT, new Map(), new Map());
+const NUMBER_REQUEST = new Request('game/getSecret', Version.DEFAULT, new Map(), new Map());
+const OBJECT_REQUEST = new Request('game/scoreSecret', Version.DEFAULT, new Map(), new Map());
+const DEFAULT_REQUEST = new Request('game/guessSecret', Version.DEFAULT, new Map(), new Map());
+
+const BOOLEAN_RESPONSE = new Response('false', { status: 200, statusText: 'OK', headers: { 'Content-Type': 'application/boolean' } });
+const NUMBER_RESPONSE = new Response('42', { status: 200, statusText: 'OK', headers: { 'Content-Type': 'application/number' } });
+const OBJECT_RESPONSE = new Response('{"result":42}', { status: 200, statusText: 'OK', headers: { 'Content-Type': 'application/json' } });
+const DEFAULT_RESPONSE = new Response('Sorry, try again', { status: 200, statusText: 'OK', headers: { 'Content-Type': 'text/plain' } });
+
+const REQUESTS = {
+    BOOLEAN_REQUEST: BOOLEAN_REQUEST,
+    NUMBER_REQUEST: NUMBER_REQUEST,
+    OBJECT_REQUEST: OBJECT_REQUEST,
+    DEFAULT_REQUEST: DEFAULT_REQUEST
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function customFetch(input: URL | RequestInfo, options: RequestInit | undefined): Promise<Response>
+{
+    const url = input.toString();
+
+    switch (url)
+    {
+        case 'http://localhost:3000/rpc/game/checkSecret?version=0.0.0&serialize=true': return Promise.resolve(BOOLEAN_RESPONSE);
+        case 'http://localhost:3000/rpc/game/getSecret?version=0.0.0&serialize=true': return Promise.resolve(NUMBER_RESPONSE);
+        case 'http://localhost:3000/rpc/game/scoreSecret?version=0.0.0&serialize=true': return Promise.resolve(OBJECT_RESPONSE);
+        default: return Promise.resolve(DEFAULT_RESPONSE);
+    }
+}
+
+globalThis.fetch = customFetch;
+
+export { REQUESTS };

--- a/packages/runtime/test/services/NodeBalancer.spec.ts
+++ b/packages/runtime/test/services/NodeBalancer.spec.ts
@@ -10,7 +10,7 @@ import { BALANCERS, NODES } from '../_fixtures/services/NodeBalancer.fixture';
 const balancer = BALANCERS.FILLED;
 const emptyBalancer = BALANCERS.EMPTY;
 
-describe('services/LocalGateway', () =>
+describe('services/NodeBalancer', () =>
 {
     describe('.getNextNode()', () =>
     {

--- a/packages/runtime/test/services/NodeMonitor.spec.ts
+++ b/packages/runtime/test/services/NodeMonitor.spec.ts
@@ -5,7 +5,7 @@ import { MONITORS, GATEWAY, NODES } from '../_fixtures/services/NodeMonitor.fixt
 
 const monitor = MONITORS.HEALTH;
 
-describe('services/LocalGateway', () =>
+describe('services/NodeMonitor', () =>
 {
     describe('.monitor()', () =>
     {

--- a/packages/runtime/test/services/Remote.spec.ts
+++ b/packages/runtime/test/services/Remote.spec.ts
@@ -1,0 +1,47 @@
+
+import { describe, expect, it } from 'vitest';
+
+import Remote from '../../src/services/Remote';
+
+import { REQUESTS } from '../_fixtures/services/Remote.fixture';
+
+const remote = new Remote('http://localhost:3000');
+const CONTENT_TYPE = 'Content-Type';
+
+describe('services/Remote', () =>
+{
+    describe('.run', () =>
+    {
+        it('should return the response as boolean', async() =>
+        {
+            const response = await remote.run(REQUESTS.BOOLEAN_REQUEST);
+
+            expect(response.result).toBe(false);
+            expect(response.getHeader(CONTENT_TYPE)).toBe('application/boolean');
+        });
+
+        it('should return the response as number', async() =>
+        {
+            const response = await remote.run(REQUESTS.NUMBER_REQUEST);
+
+            expect(response.result).toBe(42);
+            expect(response.getHeader(CONTENT_TYPE)).toBe('application/number');
+        });
+
+        it('should return the response as object', async() =>
+        {
+            const response = await remote.run(REQUESTS.OBJECT_REQUEST);
+
+            expect(response.result).toEqual({ result: 42 });
+            expect(response.getHeader(CONTENT_TYPE)).toBe('application/json');
+        });
+
+        it('should return the response as string', async() =>
+        {
+            const response = await remote.run(REQUESTS.DEFAULT_REQUEST);
+
+            expect(response.result).toBe('Sorry, try again');
+            expect(response.getHeader(CONTENT_TYPE)).toBe('text/plain');
+        });
+    });
+});

--- a/packages/runtime/test/services/Remote.spec.ts
+++ b/packages/runtime/test/services/Remote.spec.ts
@@ -1,12 +1,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import Remote from '../../src/services/Remote';
-
-import { REQUESTS } from '../_fixtures/services/Remote.fixture';
-
-const remote = new Remote('http://localhost:3000');
-const CONTENT_TYPE = 'Content-Type';
+import { REQUESTS, remote, CONTENT_TYPE } from '../_fixtures/services/Remote.fixture';
 
 describe('services/Remote', () =>
 {

--- a/packages/runtime/test/services/RemoteNode.spec.ts
+++ b/packages/runtime/test/services/RemoteNode.spec.ts
@@ -5,7 +5,7 @@ import { NODES, NODE_URL } from '../_fixtures/services/RemoteNode.fixture';
 
 const node = NODES.REMOTE;
 
-describe('services/LocalGateway', () =>
+describe('services/RemoteNode', () =>
 {
     describe('.url', () =>
     {

--- a/packages/server-nodejs/src/controllers/RPCController.ts
+++ b/packages/server-nodejs/src/controllers/RPCController.ts
@@ -238,7 +238,7 @@ export default class RPCController
     {
         const content = await this.#createResponseContent(result, serialize);
         const contentType = this.#createResponseContentType(content);
-        const responseContent = contentType === ContentTypes.TEXT ? String(content) : content;
+        const responseContent = contentType === ContentTypes.JSON ? content : String(content);
 
         response.setHeader(Headers.CONTENT_TYPE, contentType);
 
@@ -265,9 +265,13 @@ export default class RPCController
 
     #createResponseContentType(content: unknown): string
     {
-        return typeof content === 'object'
-            ? ContentTypes.JSON
-            : ContentTypes.TEXT;
+        switch(typeof content)
+        {
+            case 'boolean': return ContentTypes.BOOLEAN;
+            case 'number': return ContentTypes.NUMBER;
+            case 'object': return ContentTypes.JSON;
+            default: return ContentTypes.TEXT;
+        }
     }
 
     #setResponseHeaders(response: ExpressResponse, headers: Map<string, string>): void

--- a/packages/server-nodejs/src/definitions/ContentTypes.ts
+++ b/packages/server-nodejs/src/definitions/ContentTypes.ts
@@ -1,5 +1,7 @@
 
 const ContentTypes = {
+    BOOLEAN: 'application/boolean',
+    NUMBER: 'application/number',
     JSON: 'application/json',
     TEXT: 'text/plain',
     HTML: 'text/html',


### PR DESCRIPTION
Fixes #451

Changes proposed in this pull request:
- Introduced own content-types to indicate the return type (boolean / number)
- Set the return type based on the content
- Parse return value based on content type header

@MaskingTechnology/jitar
