### PR TITLE
chore(examples): always use latest version of jitar

### DIFF
--- a/examples/apps/contact-list/package.json
+++ b/examples/apps/contact-list/package.json
@@ -14,13 +14,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "jitar": "^0.6.0",
+    "jitar": "*",
     "mongodb": "^6.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@jitar/plugin-vite": "^0.6.0",
+    "@jitar/plugin-vite": "*",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react": "^4.2.1",

--- a/examples/concepts/access-protection/package.json
+++ b/examples/concepts/access-protection/package.json
@@ -11,6 +11,6 @@
         "worker-game": "node --experimental-network-imports --env-file=.env dist/jitar.js --config=services/game.json"
     },
     "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
     }
 }

--- a/examples/concepts/construction/package.json
+++ b/examples/concepts/construction/package.json
@@ -7,6 +7,6 @@
         "standalone": "node --experimental-network-imports dist/jitar.js --config=services/standalone.json"
     },
     "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
     }
 }

--- a/examples/concepts/cors/package.json
+++ b/examples/concepts/cors/package.json
@@ -11,7 +11,7 @@
         "client": "node dist/client.js"
     },
     "dependencies": {
-        "jitar": "^0.6.0",
+        "jitar": "*",
         "express": "^4.18.2"
     },
     "devDependencies": {

--- a/examples/concepts/data-transportation/package.json
+++ b/examples/concepts/data-transportation/package.json
@@ -11,6 +11,6 @@
         "worker-helpdesk": "node --experimental-network-imports dist/jitar.js --config=services/helpdesk.json"
     },
     "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
     }
 }

--- a/examples/concepts/error-handling/package.json
+++ b/examples/concepts/error-handling/package.json
@@ -11,6 +11,6 @@
         "worker-process": "node --experimental-network-imports dist/jitar.js --config=services/process.json"
     },
     "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
     }
 }

--- a/examples/concepts/health-checks/package.json
+++ b/examples/concepts/health-checks/package.json
@@ -7,6 +7,6 @@
         "standalone": "node --experimental-network-imports dist/jitar.js --config=services/standalone.json"
     },
     "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
     }
 }

--- a/examples/concepts/hello-world/package.json
+++ b/examples/concepts/hello-world/package.json
@@ -7,6 +7,6 @@
         "standalone": "node --experimental-network-imports dist/jitar.js --config=services/standalone.json"
     },
     "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
     }
 }

--- a/examples/concepts/load-balancing/package.json
+++ b/examples/concepts/load-balancing/package.json
@@ -11,6 +11,6 @@
         "worker2": "node --experimental-network-imports dist/jitar.js --config=services/worker2.json"
     },
     "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
     }
 }

--- a/examples/concepts/middleware/package.json
+++ b/examples/concepts/middleware/package.json
@@ -7,6 +7,6 @@
         "standalone": "node --experimental-network-imports dist/jitar.js --config=services/standalone.json"
     },
     "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
     }
 }

--- a/examples/concepts/multi-version/package.json
+++ b/examples/concepts/multi-version/package.json
@@ -7,6 +7,6 @@
         "standalone": "node --experimental-network-imports dist/jitar.js --config=services/standalone.json"
     },
     "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
     }
 }

--- a/examples/concepts/node-client/package.json
+++ b/examples/concepts/node-client/package.json
@@ -8,6 +8,6 @@
         "client": "node --experimental-network-imports --no-warnings dist/client.js"
     },
     "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
     }
 }

--- a/examples/concepts/overrides/package.json
+++ b/examples/concepts/overrides/package.json
@@ -7,6 +7,6 @@
         "standalone": "node --experimental-network-imports dist/jitar.js --config=services/standalone.json"
     },
     "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
     }
 }

--- a/examples/concepts/segmentation/package.json
+++ b/examples/concepts/segmentation/package.json
@@ -11,6 +11,6 @@
         "worker-process": "node --experimental-network-imports dist/jitar.js --config=services/process.json"
     },
     "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,13 +61,13 @@
       "name": "jitar-contact-list",
       "version": "0.0.0",
       "dependencies": {
-        "jitar": "^0.6.0",
+        "jitar": "*",
         "mongodb": "^6.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@jitar/plugin-vite": "^0.6.0",
+        "@jitar/plugin-vite": "*",
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
         "@vitejs/plugin-react": "^4.2.1",
@@ -78,20 +78,20 @@
     "examples/concepts/access-protection": {
       "name": "jitar-access-protection-example",
       "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
       }
     },
     "examples/concepts/construction": {
       "name": "jitar-construction-example",
       "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
       }
     },
     "examples/concepts/cors": {
       "name": "jitar-cors-example",
       "dependencies": {
         "express": "^4.18.2",
-        "jitar": "^0.6.0"
+        "jitar": "*"
       },
       "devDependencies": {
         "cpx2": "^7.0.1",
@@ -120,61 +120,61 @@
     "examples/concepts/data-transportation": {
       "name": "jitar-data-transportation-example",
       "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
       }
     },
     "examples/concepts/error-handling": {
       "name": "jitar-error-handling-example",
       "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
       }
     },
     "examples/concepts/health-checks": {
       "name": "jitar-health-checks-example",
       "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
       }
     },
     "examples/concepts/hello-world": {
       "name": "jitar-helloworld-example",
       "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
       }
     },
     "examples/concepts/load-balancing": {
       "name": "jitar-load-balancing-example",
       "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
       }
     },
     "examples/concepts/middleware": {
       "name": "jitar-middleware-example",
       "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
       }
     },
     "examples/concepts/multi-version": {
       "name": "jitar-multi-version-example",
       "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
       }
     },
     "examples/concepts/node-client": {
       "name": "jitar-node-client-example",
       "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
       }
     },
     "examples/concepts/overrides": {
       "name": "jitar-overrides-example",
       "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
       }
     },
     "examples/concepts/segmentation": {
       "name": "jitar-segmentation-example",
       "dependencies": {
-        "jitar": "^0.6.0"
+        "jitar": "*"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
Fixes #467

Changes proposed in this pull request:
- always use the latest version of jitar, so we can test our changes with confidence

@MaskingTechnology/jitar
