### PR TITLE
chore: display breaking changes explicitly in changelog

### DIFF
--- a/changelog.hbs
+++ b/changelog.hbs
@@ -4,6 +4,13 @@
 
   {{#commit-list
     merges
+    heading='### BREAKING CHANGES'
+    message='^\w+(?:(\(\w+\))|)!:'}}
+  * \[[{{id}}]({{href}})] {{commit.subject}} by {{commit.author}}
+  {{/commit-list}}
+
+  {{#commit-list
+    merges
     heading='### Features'
     message='feat(?:(\(\w+\))|):'}}
   * \[[{{id}}]({{href}})] {{commit.subject}} by {{commit.author}}
@@ -26,7 +33,7 @@
   {{#commit-list
     merges
     heading='### Other'
-    exclude='(feat(?:(\(\w+\))|):)|(chore(?:(\(\w+\))|):)|(build(?:(\(\w+\))|):)|(npm(?:(\(\w+\))|):)|(fix(?:(\(\w+\))|):)|(bug(?:(\(\w+\))|):)'}}
+    exclude='(feat(?:(\(\w+\))|):)|(chore(?:(\(\w+\))|):)|(build(?:(\(\w+\))|):)|(npm(?:(\(\w+\))|):)|(fix(?:(\(\w+\))|):)|(bug(?:(\(\w+\))|):)|(^\w+(?:(\(\w+\))|)!:)'}}
   * \[[{{id}}]({{href}})] {{commit.subject}} by {{commit.author}}
   {{/commit-list}}
 


### PR DESCRIPTION
Fixes #469 

Changes proposed in this pull request:
- Breaking changes regex added to the handlebar template

@MaskingTechnology/jitar
