### PR TITLE
fix(runtime): environment specific loading of Jitar

### DIFF
--- a/packages/runtime/src/utils/Environment.ts
+++ b/packages/runtime/src/utils/Environment.ts
@@ -1,0 +1,15 @@
+
+const hasWindowObject = typeof window !== 'undefined';
+
+export default class Environment
+{
+    static isBrowser(): boolean
+    {
+        return hasWindowObject;
+    }
+
+    static isServer(): boolean
+    {
+        return hasWindowObject === false;
+    }
+}

--- a/packages/runtime/src/utils/ModuleLoader.ts
+++ b/packages/runtime/src/utils/ModuleLoader.ts
@@ -4,6 +4,7 @@ import ModuleNotLoaded from '../errors/ModuleNotLoaded.js';
 
 import Module from '../types/Module.js';
 import ModuleImporter from '../types/ModuleImporter.js';
+import Environment from './Environment.js';
 
 import UrlRewriter from './UrlRewriter.js';
 
@@ -33,7 +34,9 @@ export default class ModuleLoader
 
         if (specifier.startsWith('/jitar'))
         {
-            return this.#import('JITAR_LIBRARY_NAME');
+            return Environment.isServer()
+                ? this.#import('JITAR_LIBRARY_NAME')
+                : this.#import(specifier);
         }
 
         const filename = this.assureExtension(specifier);


### PR DESCRIPTION
Fixes #474 

Changes proposed in this pull request:
- Added environment util that determines the runtime (server or browser)
- Loading Jitar as library when running on server
- Loading Jitar from repository when running on browser

@MaskingTechnology/jitar
