### PR TITLE
chore(deps): update express

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4683,9 +4683,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5626,16 +5626,16 @@
       "dev": true
     },
     "node_modules/express": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
-      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -14233,7 +14233,7 @@
       "dependencies": {
         "@jitar/caching": "^0.7.1",
         "@jitar/runtime": "^0.7.1",
-        "express": "^4.18.3",
+        "express": "^4.19.2",
         "express-http-proxy": "^2.0.0",
         "fs-extra": "^11.2.0",
         "glob-promise": "6.0.5",

--- a/packages/server-nodejs/package.json
+++ b/packages/server-nodejs/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "@jitar/caching": "^0.7.1",
         "@jitar/runtime": "^0.7.1",
-        "express": "^4.18.3",
+        "express": "^4.19.2",
         "express-http-proxy": "^2.0.0",
         "fs-extra": "^11.2.0",
         "glob-promise": "6.0.5",


### PR DESCRIPTION
Fixes #507 

Changes proposed in this pull request:
- update express to fix [CVE-2024-29041](https://github.com/advisories/GHSA-rv95-896h-c2vc)

@MaskingTechnology/jitar
