### PR TITLE
feat(services): deregister worker on exit

### DIFF
--- a/packages/cli/src/commands/StartServer.ts
+++ b/packages/cli/src/commands/StartServer.ts
@@ -61,7 +61,16 @@ export default class StartServer implements Command
 
     #runServer(httpServer: HttpServer): Promise<void>
     {
-        process.on('SIGINT', async () => httpServer.stop());
+        let isShuttingDown = false;
+
+        process.on('SIGINT', async () => 
+        {
+            if (isShuttingDown) return;
+
+            isShuttingDown = true;
+
+            httpServer.stop();
+        });
 
         console.log(banner);
 

--- a/packages/http/src/HttpRemote.ts
+++ b/packages/http/src/HttpRemote.ts
@@ -76,10 +76,10 @@ export default class HttpRemote implements Remote
         await this.#callRemote(remoteUrl, options);
     }
 
-    async removeWorker(url: string, procedureNames: string[], trustKey?: string): Promise<void>
+    async removeWorker(url: string, trustKey?: string): Promise<void>
     {
         const remoteUrl = `${this.#url}/workers`;
-        const body = { url, procedureNames, trustKey };
+        const body = { url, trustKey };
         const options =
         {
             method: 'DELETE',

--- a/packages/http/src/HttpRemote.ts
+++ b/packages/http/src/HttpRemote.ts
@@ -1,6 +1,6 @@
 
 import { ErrorConverter, Request, Response as ResultResponse } from '@jitar/execution';
-import type { Remote, Worker } from '@jitar/services';
+import type { Remote } from '@jitar/services';
 import { File } from '@jitar/sourcing';
 
 import HeaderKeys from './definitions/HeaderKeys';

--- a/packages/http/src/HttpRemote.ts
+++ b/packages/http/src/HttpRemote.ts
@@ -1,16 +1,19 @@
 
 import { ErrorConverter, Request, Response as ResultResponse } from '@jitar/execution';
-import { Remote } from '@jitar/services';
+import type { Remote, Worker } from '@jitar/services';
 import { File } from '@jitar/sourcing';
 
 import HeaderKeys from './definitions/HeaderKeys';
 import HeaderValues from './definitions/HeaderValues';
+import { Validator } from '@jitar/validation';
+import InvalidWorkerId from './errors/InvalidWorkerId';
 
 export default class HttpRemote implements Remote
 {
     readonly #url: string;
     
     readonly #errorConverter = new ErrorConverter();
+    readonly #validator = new Validator();
 
     constructor(url: string)
     {
@@ -62,7 +65,7 @@ export default class HttpRemote implements Remote
         return new Map(Object.entries(health));
     }
 
-    async addWorker(url: string, procedureNames: string[], trustKey?: string): Promise<void>
+    async addWorker(url: string, procedureNames: string[], trustKey?: string): Promise<string>
     {
         const remoteUrl = `${this.#url}/workers`;
         const body = { url, procedureNames, trustKey };
@@ -73,18 +76,37 @@ export default class HttpRemote implements Remote
             body: JSON.stringify(body)
         };
 
-        await this.#callRemote(remoteUrl, options);
+        const response = await this.#callRemote(remoteUrl, options);
+
+        const contentType = response.headers.get(HeaderKeys.CONTENT_TYPE);
+
+        if (contentType === null || contentType.includes(HeaderValues.APPLICATION_JSON) === false)
+        {
+            throw new InvalidWorkerId();
+        }
+
+        const result = await response.json();
+
+        const validation = this.#validator.validate(result,
+        {
+            id: { type: 'string', required: true }
+        });
+
+        if (validation.valid === false)
+        {
+            throw new InvalidWorkerId();
+        }
+
+        return result.id;
     }
 
-    async removeWorker(url: string, trustKey?: string): Promise<void>
+    async removeWorker(id: string): Promise<void>
     {
-        const remoteUrl = `${this.#url}/workers`;
-        const body = { url, trustKey };
+        const remoteUrl = `${this.#url}/workers?id=${id}`;
         const options =
         {
             method: 'DELETE',
-            headers: { 'Content-Type': HeaderValues.APPLICATION_JSON },
-            body: JSON.stringify(body)
+            headers: { 'Content-Type': HeaderValues.APPLICATION_JSON }
         };
 
         await this.#callRemote(remoteUrl, options);

--- a/packages/http/src/HttpRemote.ts
+++ b/packages/http/src/HttpRemote.ts
@@ -76,6 +76,20 @@ export default class HttpRemote implements Remote
         await this.#callRemote(remoteUrl, options);
     }
 
+    async removeWorker(url: string, procedureNames: string[], trustKey?: string): Promise<void>
+    {
+        const remoteUrl = `${this.#url}/workers`;
+        const body = { url, procedureNames, trustKey };
+        const options =
+        {
+            method: 'DELETE',
+            headers: { 'Content-Type': HeaderValues.APPLICATION_JSON },
+            body: JSON.stringify(body)
+        };
+
+        await this.#callRemote(remoteUrl, options);
+    }
+
     async run(request: Request): Promise<ResultResponse>
     {
         request.setHeader(HeaderKeys.CONTENT_TYPE, HeaderValues.APPLICATION_JSON);

--- a/packages/http/src/HttpRemote.ts
+++ b/packages/http/src/HttpRemote.ts
@@ -102,7 +102,7 @@ export default class HttpRemote implements Remote
 
     async removeWorker(id: string): Promise<void>
     {
-        const remoteUrl = `${this.#url}/workers?id=${id}`;
+        const remoteUrl = `${this.#url}/workers/${id}`;
         const options =
         {
             method: 'DELETE',

--- a/packages/http/src/HttpServer.ts
+++ b/packages/http/src/HttpServer.ts
@@ -63,6 +63,7 @@ export default class HttpServer
         this.#app.options('/rpc/*', this.#runOptions.bind(this));
 
         this.#app.post('/workers', this.#addWorker.bind(this));
+        this.#app.delete('/workers', this.#removeWorker.bind(this));
 
         this.#app.get('*', this.#provide.bind(this));
     }
@@ -177,6 +178,40 @@ export default class HttpServer
         try
         {
             const serverResponse = await this.#server.addWorker({ url, procedureNames, trustKey });
+
+            return this.#transformResponse(response, serverResponse);
+        }
+        catch (error: unknown)
+        {
+            const message = error instanceof Error ? error.message : 'Server error';
+
+            return response.status(500).send(message);
+        }
+    }
+
+    async #removeWorker(request: Request, response: Response): Promise<Response>
+    {
+        const args = this.#extractBodyArguments(request);
+
+        const validation = this.#validator.validate(args,
+        {
+            url: { type: 'url', required: true },
+            procedureNames: { type: 'list', required: true, items: { type: 'string' } },
+            trustKey: { type: 'string', required: false }
+        });
+
+        if (validation.valid === false)
+        {
+            return response.status(400).send(validation.errors.join('\n'));
+        }
+
+        const url = args.url as string;
+        const procedureNames = args.procedureNames as string[];
+        const trustKey = args.trustKey as string | undefined;
+
+        try
+        {
+            const serverResponse = await this.#server.removeWorker({ url, procedureNames, trustKey });
 
             return this.#transformResponse(response, serverResponse);
         }

--- a/packages/http/src/HttpServer.ts
+++ b/packages/http/src/HttpServer.ts
@@ -196,7 +196,6 @@ export default class HttpServer
         const validation = this.#validator.validate(args,
         {
             url: { type: 'url', required: true },
-            procedureNames: { type: 'list', required: true, items: { type: 'string' } },
             trustKey: { type: 'string', required: false }
         });
 
@@ -206,12 +205,11 @@ export default class HttpServer
         }
 
         const url = args.url as string;
-        const procedureNames = args.procedureNames as string[];
         const trustKey = args.trustKey as string | undefined;
 
         try
         {
-            const serverResponse = await this.#server.removeWorker({ url, procedureNames, trustKey });
+            const serverResponse = await this.#server.removeWorker({ url, trustKey });
 
             return this.#transformResponse(response, serverResponse);
         }

--- a/packages/http/src/HttpServer.ts
+++ b/packages/http/src/HttpServer.ts
@@ -63,7 +63,7 @@ export default class HttpServer
         this.#app.options('/rpc/*', this.#runOptions.bind(this));
 
         this.#app.post('/workers', this.#addWorker.bind(this));
-        this.#app.delete('/workers', this.#removeWorker.bind(this));
+        this.#app.delete('/workers/:id', this.#removeWorker.bind(this));
 
         this.#app.get('*', this.#provide.bind(this));
     }
@@ -191,7 +191,7 @@ export default class HttpServer
 
     async #removeWorker(request: Request, response: Response): Promise<Response>
     {
-        const args = this.#extractQueryArguments(request);
+        const args = { id: request.params.id };
 
         const validation = this.#validator.validate(args,
         {

--- a/packages/http/src/HttpServer.ts
+++ b/packages/http/src/HttpServer.ts
@@ -191,12 +191,11 @@ export default class HttpServer
 
     async #removeWorker(request: Request, response: Response): Promise<Response>
     {
-        const args = this.#extractBodyArguments(request);
+        const args = this.#extractQueryArguments(request);
 
         const validation = this.#validator.validate(args,
         {
-            url: { type: 'url', required: true },
-            trustKey: { type: 'string', required: false }
+            id: { type: 'string', required: true },
         });
 
         if (validation.valid === false)
@@ -204,12 +203,11 @@ export default class HttpServer
             return response.status(400).send(validation.errors.join('\n'));
         }
 
-        const url = args.url as string;
-        const trustKey = args.trustKey as string | undefined;
+        const id = args.id as string;
 
         try
         {
-            const serverResponse = await this.#server.removeWorker({ url, trustKey });
+            const serverResponse = await this.#server.removeWorker({ id });
 
             return this.#transformResponse(response, serverResponse);
         }

--- a/packages/http/src/errors/InvalidWorkerId.ts
+++ b/packages/http/src/errors/InvalidWorkerId.ts
@@ -1,0 +1,8 @@
+
+export default class InvalidWorkerId extends Error
+{
+    constructor()
+    {
+        super('Invalid worker id');
+    }
+}

--- a/packages/runtime/src/server/Server.ts
+++ b/packages/runtime/src/server/Server.ts
@@ -197,9 +197,9 @@ export default class Server extends Runtime
                 throw new BadRequest('Cannot add worker to remote gateway');
             }
 
-            const worker = this.#buildRemoteWorker(addRequest.url, addRequest.procedureNames);
+            const worker = this.#buildRemoteWorker(addRequest.url, addRequest.procedureNames, addRequest.trustKey);
 
-            await runner.addWorker(worker, addRequest.trustKey);
+            await runner.addWorker(worker);
 
             this.#logger.info('Added worker:', worker.url);
 
@@ -226,9 +226,9 @@ export default class Server extends Runtime
                 throw new BadRequest('Cannot remove worker from remote gateway');
             }
 
-            const worker = this.#buildRemoteWorker(removeRequest.url, removeRequest.procedureNames);
+            const worker = this.#buildRemoteWorker(removeRequest.url, [], removeRequest.trustKey);
 
-            await runner.removeWorker(worker, removeRequest.trustKey);
+            await runner.removeWorker(worker);
 
             this.#logger.info('Removed worker:', worker.url);
 
@@ -408,11 +408,11 @@ export default class Server extends Runtime
         return StatusCodes.SERVER_ERROR;
     }
 
-    #buildRemoteWorker(url: string, procedures: string[]): RemoteWorker
+    #buildRemoteWorker(url: string, procedures: string[], trustKey?: string): RemoteWorker
     {
         const remote = this.#remoteBuilder.build(url);
         const procedureNames = new Set<string>(procedures);
 
-        return new RemoteWorker({ url, remote, procedureNames });
+        return new RemoteWorker({ url, trustKey, remote, procedureNames });
     }
 }

--- a/packages/runtime/src/server/types/RemoveWorkerRequest.ts
+++ b/packages/runtime/src/server/types/RemoveWorkerRequest.ts
@@ -1,8 +1,7 @@
 
 type RemoveWorkerRequest =
 {
-    url: string;
-    trustKey?: string;
+    id: string
 };
 
 export default RemoveWorkerRequest;

--- a/packages/runtime/src/server/types/RemoveWorkerRequest.ts
+++ b/packages/runtime/src/server/types/RemoveWorkerRequest.ts
@@ -1,0 +1,9 @@
+
+type RemoveWorkerRequest =
+{
+    url: string;
+    procedureNames: string[];
+    trustKey?: string;
+};
+
+export default RemoveWorkerRequest;

--- a/packages/runtime/src/server/types/RemoveWorkerRequest.ts
+++ b/packages/runtime/src/server/types/RemoveWorkerRequest.ts
@@ -2,7 +2,6 @@
 type RemoveWorkerRequest =
 {
     url: string;
-    procedureNames: string[];
     trustKey?: string;
 };
 

--- a/packages/services/src/Remote.ts
+++ b/packages/services/src/Remote.ts
@@ -2,8 +2,6 @@
 import { Request, Response as ResultResponse } from '@jitar/execution';
 import { File } from '@jitar/sourcing';
 
-import type Worker from './worker/Worker';
-
 interface Remote
 {
     connect(): Promise<void>;

--- a/packages/services/src/Remote.ts
+++ b/packages/services/src/Remote.ts
@@ -16,6 +16,8 @@ interface Remote
 
     addWorker(workerUrl: string, procedureNames: string[], trustKey?: string): Promise<void>
 
+    removeWorker(workerUrl: string, procedureNames: string[], trustKey?: string): Promise<void>
+
     run(request: Request): Promise<ResultResponse>;
 }
 

--- a/packages/services/src/Remote.ts
+++ b/packages/services/src/Remote.ts
@@ -2,6 +2,8 @@
 import { Request, Response as ResultResponse } from '@jitar/execution';
 import { File } from '@jitar/sourcing';
 
+import type Worker from './worker/Worker';
+
 interface Remote
 {
     connect(): Promise<void>;
@@ -14,9 +16,9 @@ interface Remote
 
     getHealth(): Promise<Map<string, boolean>>;
 
-    addWorker(workerUrl: string, procedureNames: string[], trustKey?: string): Promise<void>
+    addWorker(workerUrl: string, procedureNames: string[], trustKey?: string): Promise<string>
 
-    removeWorker(workerUrl: string, trustKey?: string): Promise<void>
+    removeWorker(id: string): Promise<void>
 
     run(request: Request): Promise<ResultResponse>;
 }

--- a/packages/services/src/Remote.ts
+++ b/packages/services/src/Remote.ts
@@ -16,7 +16,7 @@ interface Remote
 
     addWorker(workerUrl: string, procedureNames: string[], trustKey?: string): Promise<void>
 
-    removeWorker(workerUrl: string, procedureNames: string[], trustKey?: string): Promise<void>
+    removeWorker(workerUrl: string, trustKey?: string): Promise<void>
 
     run(request: Request): Promise<ResultResponse>;
 }

--- a/packages/services/src/gateway/Gateway.ts
+++ b/packages/services/src/gateway/Gateway.ts
@@ -5,6 +5,8 @@ import Worker from '../worker/Worker';
 interface Gateway extends RunnerService
 {
     addWorker(worker: Worker): Promise<void>;
+
+    removeWorker(worker: Worker): Promise<void>;
 }
 
 export default Gateway;

--- a/packages/services/src/gateway/Gateway.ts
+++ b/packages/services/src/gateway/Gateway.ts
@@ -1,10 +1,10 @@
 
 import RunnerService from '../RunnerService';
-import Worker from '../worker/Worker';
+import type Worker from '../worker/Worker';
 
 interface Gateway extends RunnerService
 {
-    addWorker(worker: Worker): Promise<void>;
+    addWorker(worker: Worker): Promise<string>;
 
     removeWorker(worker: Worker): Promise<void>;
 }

--- a/packages/services/src/gateway/LocalGateway.ts
+++ b/packages/services/src/gateway/LocalGateway.ts
@@ -2,14 +2,13 @@
 import { Response } from '@jitar/execution';
 import type { Request } from '@jitar/execution';
 
-import Worker from '../worker/Worker';
+import type Worker from '../worker/Worker';
 
 import Gateway from './Gateway';
 import WorkerManager from './WorkerManager';
 import WorkerMonitor from './WorkerMonitor';
 
 import InvalidTrustKey from './errors/InvalidTrustKey';
-import UnknownWorker from './errors/UnknownWorker';
 
 type Configuration =
 {
@@ -57,7 +56,7 @@ export default class LocalGateway implements Gateway
         return new Map();
     }
 
-    async addWorker(worker: Worker): Promise<void>
+    async addWorker(worker: Worker): Promise<string>
     {
         if (this.#isInvalidTrustKey(worker.trustKey))
         {
@@ -67,21 +66,14 @@ export default class LocalGateway implements Gateway
         return this.#workerManager.addWorker(worker);
     }
 
+    getWorker(id: string): Worker
+    {
+        return this.#workerManager.getWorker(id);
+    }
+
     async removeWorker(worker: Worker): Promise<void>
     {
-        if (this.#isInvalidTrustKey(worker.trustKey))
-        {
-            throw new InvalidTrustKey();
-        }
-
-        const registeredWorker = this.#workerManager.workers.find(registeredWorker => registeredWorker.url === worker.url);
-        
-        if (registeredWorker === undefined)
-        {
-            throw new UnknownWorker(worker.url);
-        }
-
-        return this.#workerManager.removeWorker(registeredWorker);
+        return this.#workerManager.removeWorker(worker);
     }
 
     getProcedureNames(): string[]

--- a/packages/services/src/gateway/LocalGateway.ts
+++ b/packages/services/src/gateway/LocalGateway.ts
@@ -66,6 +66,16 @@ export default class LocalGateway implements Gateway
         return this.#workerManager.addWorker(worker);
     }
 
+    async removeWorker(worker: Worker, trustKey?: string): Promise<void>
+    {
+        if (this.#isInvalidTrustKey(trustKey))
+        {
+            throw new InvalidTrustKey();
+        }
+        
+        return this.#workerManager.removeWorker(worker);
+    }
+
     getProcedureNames(): string[]
     {
         return this.#workerManager.getProcedureNames();

--- a/packages/services/src/gateway/LocalGateway.ts
+++ b/packages/services/src/gateway/LocalGateway.ts
@@ -9,6 +9,7 @@ import WorkerManager from './WorkerManager';
 import WorkerMonitor from './WorkerMonitor';
 
 import InvalidTrustKey from './errors/InvalidTrustKey';
+import UnknownWorker from './errors/UnknownWorker';
 
 type Configuration =
 {
@@ -56,9 +57,9 @@ export default class LocalGateway implements Gateway
         return new Map();
     }
 
-    async addWorker(worker: Worker, trustKey?: string): Promise<void>
+    async addWorker(worker: Worker): Promise<void>
     {
-        if (this.#isInvalidTrustKey(trustKey))
+        if (this.#isInvalidTrustKey(worker.trustKey))
         {
             throw new InvalidTrustKey();
         }
@@ -66,14 +67,21 @@ export default class LocalGateway implements Gateway
         return this.#workerManager.addWorker(worker);
     }
 
-    async removeWorker(worker: Worker, trustKey?: string): Promise<void>
+    async removeWorker(worker: Worker): Promise<void>
     {
-        if (this.#isInvalidTrustKey(trustKey))
+        if (this.#isInvalidTrustKey(worker.trustKey))
         {
             throw new InvalidTrustKey();
         }
+
+        const registeredWorker = this.#workerManager.workers.find(registeredWorker => registeredWorker.url === worker.url);
         
-        return this.#workerManager.removeWorker(worker);
+        if (registeredWorker === undefined)
+        {
+            throw new UnknownWorker(worker.url);
+        }
+
+        return this.#workerManager.removeWorker(registeredWorker);
     }
 
     getProcedureNames(): string[]

--- a/packages/services/src/gateway/RemoteGateway.ts
+++ b/packages/services/src/gateway/RemoteGateway.ts
@@ -2,8 +2,8 @@
 import { NotImplemented } from '@jitar/errors';
 import { Request, Response } from '@jitar/execution';
 
-import Remote from '../Remote';
-import Worker from '../worker/Worker';
+import type Remote from '../Remote';
+import type Worker from '../worker/Worker';
 
 import Gateway from './Gateway';
 
@@ -59,14 +59,14 @@ export default class RemoteGateway implements Gateway
         throw new NotImplemented();
     }
 
-    addWorker(worker: Worker): Promise<void>
+    addWorker(worker: Worker): Promise<string>
     {
         return this.#remote.addWorker(worker.url, worker.getProcedureNames(), worker.trustKey);
     }
 
     removeWorker(worker: Worker): Promise<void>
     {
-        return this.#remote.removeWorker(worker.url, worker.trustKey);
+        return this.#remote.removeWorker(worker.id as string);
     }
 
     run(request: Request): Promise<Response>

--- a/packages/services/src/gateway/RemoteGateway.ts
+++ b/packages/services/src/gateway/RemoteGateway.ts
@@ -66,7 +66,7 @@ export default class RemoteGateway implements Gateway
 
     removeWorker(worker: Worker): Promise<void>
     {
-        return this.#remote.removeWorker(worker.url, worker.getProcedureNames(), worker.trustKey);
+        return this.#remote.removeWorker(worker.url, worker.trustKey);
     }
 
     run(request: Request): Promise<Response>

--- a/packages/services/src/gateway/RemoteGateway.ts
+++ b/packages/services/src/gateway/RemoteGateway.ts
@@ -64,6 +64,11 @@ export default class RemoteGateway implements Gateway
         return this.#remote.addWorker(worker.url, worker.getProcedureNames(), worker.trustKey);
     }
 
+    removeWorker(worker: Worker): Promise<void>
+    {
+        return this.#remote.removeWorker(worker.url, worker.getProcedureNames(), worker.trustKey);
+    }
+
     run(request: Request): Promise<Response>
     {
         return this.#remote.run(request);

--- a/packages/services/src/gateway/WorkerManager.ts
+++ b/packages/services/src/gateway/WorkerManager.ts
@@ -38,7 +38,7 @@ export default class WorkerManager implements Runner
 
     addWorker(worker: Worker): string
     {
-        worker.id = this.#idGenerator.generateUUID();
+        worker.id = this.#idGenerator.generate();
 
         this.#workers.set(worker.id, worker);
 

--- a/packages/services/src/gateway/WorkerManager.ts
+++ b/packages/services/src/gateway/WorkerManager.ts
@@ -4,10 +4,15 @@ import { ProcedureNotFound, Request, Response, Runner } from '@jitar/execution';
 import Worker from '../worker/Worker';
 import WorkerBalancer from './WorkerBalancer';
 
+import IdGenerator from './utils/IdGenerator';
+import UnknownWorker from './errors/UnknownWorker';
+
 export default class WorkerManager implements Runner
 {
-    readonly #workers = new Set<Worker>();
+    readonly #workers = new Map<string, Worker>();
     readonly #balancers = new Map<string, WorkerBalancer>();
+
+    readonly #idGenerator = new IdGenerator();
 
     get workers()
     {
@@ -31,9 +36,11 @@ export default class WorkerManager implements Runner
         return procedureNames.includes(fqn);
     }
 
-    async addWorker(worker: Worker): Promise<void>
+    addWorker(worker: Worker): string
     {
-        this.#workers.add(worker);
+        worker.id = this.#idGenerator.generateUUID();
+
+        this.#workers.set(worker.id, worker);
 
         for (const name of worker.getProcedureNames())
         {
@@ -41,11 +48,25 @@ export default class WorkerManager implements Runner
 
             balancer.addWorker(worker);
         }
+
+        return worker.id;
+    }
+
+    getWorker(id: string)
+    {
+        const worker = this.#workers.get(id);
+
+        if (worker === undefined)
+        {
+            throw new UnknownWorker(id);
+        }
+
+        return worker;
     }
 
     removeWorker(worker: Worker): void
     {
-        this.#workers.delete(worker);
+        this.#workers.delete(worker.id as string);
 
         for (const name of worker.getProcedureNames())
         {

--- a/packages/services/src/gateway/errors/UnknownWorker.ts
+++ b/packages/services/src/gateway/errors/UnknownWorker.ts
@@ -1,0 +1,16 @@
+
+import { ServerError } from '@jitar/errors';
+
+export default class UnknownWorker extends ServerError
+{
+    #url: string;
+
+    constructor(url: string)
+    {
+        super(`Unknown worker for '${url}'`);
+
+        this.#url = url;
+    }
+
+    get url() { return this.#url; }
+}

--- a/packages/services/src/gateway/errors/UnknownWorker.ts
+++ b/packages/services/src/gateway/errors/UnknownWorker.ts
@@ -7,7 +7,7 @@ export default class UnknownWorker extends ServerError
 
     constructor(url: string)
     {
-        super(`Unknown worker for '${url}'`);
+        super(`Unknown worker id '${url}'`);
 
         this.#url = url;
     }

--- a/packages/services/src/gateway/errors/UnknownWorker.ts
+++ b/packages/services/src/gateway/errors/UnknownWorker.ts
@@ -3,14 +3,14 @@ import { ServerError } from '@jitar/errors';
 
 export default class UnknownWorker extends ServerError
 {
-    #url: string;
+    #id: string;
 
-    constructor(url: string)
+    constructor(id: string)
     {
-        super(`Unknown worker id '${url}'`);
+        super(`Unknown worker id '${id}'`);
 
-        this.#url = url;
+        this.#id = id;
     }
-
-    get url() { return this.#url; }
+    
+    get id() { return this.#id; }
 }

--- a/packages/services/src/gateway/utils/IdGenerator.ts
+++ b/packages/services/src/gateway/utils/IdGenerator.ts
@@ -1,0 +1,10 @@
+
+import crypto from 'crypto';
+
+export default class IdGenerator
+{
+    generateUUID(): string
+    {
+        return crypto.randomUUID();
+    }
+}

--- a/packages/services/src/gateway/utils/IdGenerator.ts
+++ b/packages/services/src/gateway/utils/IdGenerator.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto';
 
 export default class IdGenerator
 {
-    generateUUID(): string
+    generate(): string
     {
         return crypto.randomUUID();
     }

--- a/packages/services/src/worker/LocalWorker.ts
+++ b/packages/services/src/worker/LocalWorker.ts
@@ -57,7 +57,7 @@ export default class LocalWorker implements Worker
     {
         if (this.#gateway !== undefined)
         {
-            // TODO: Remove worker from gateway (Github issue #410)
+            await this.#gateway.removeWorker(this);
             await this.#gateway.stop();
         }
     }

--- a/packages/services/src/worker/LocalWorker.ts
+++ b/packages/services/src/worker/LocalWorker.ts
@@ -13,15 +13,16 @@ const JITAR_DATA_ENCODING_KEY = 'X-Jitar-Data-Encoding';
 const JITAR_DATA_ENCODING_VALUE = 'serialized';
 
 type Configuration =
-    {
-        url: string;
-        trustKey?: string;
-        gateway?: Gateway;
-        executionManager: ExecutionManager;
-    };
+{
+    url: string;
+    trustKey?: string;
+    gateway?: Gateway;
+    executionManager: ExecutionManager;
+};
 
 export default class LocalWorker implements Worker
 {
+    #id: string | undefined;
     readonly #url: string;
     readonly #trustKey?: string;
     readonly #gateway?: Gateway;
@@ -40,6 +41,10 @@ export default class LocalWorker implements Worker
         this.#serializer = SerializerBuilder.build(classResolver);
     }
 
+    get id(): string | undefined { return this.#id; }
+
+    set id(id: string) { this.#id = id; }
+
     get url() { return this.#url; }
 
     get trustKey() { return this.#trustKey; }
@@ -49,13 +54,13 @@ export default class LocalWorker implements Worker
         if (this.#gateway !== undefined)
         {
             await this.#gateway.start();
-            await this.#gateway.addWorker(this);
+            this.#id = await this.#gateway.addWorker(this);
         }
     }
 
     async stop(): Promise<void>
     {
-        if (this.#gateway !== undefined)
+        if (this.#gateway !== undefined && this.#id !== undefined)
         {
             await this.#gateway.removeWorker(this);
             await this.#gateway.stop();

--- a/packages/services/src/worker/RemoteWorker.ts
+++ b/packages/services/src/worker/RemoteWorker.ts
@@ -8,6 +8,7 @@ import Worker from './Worker';
 type Configuration =
 {
     url: string;
+    trustKey?: string;
     procedureNames: Set<string>;
     remote: Remote;
 };
@@ -15,19 +16,21 @@ type Configuration =
 export default class RemoteWorker implements Worker
 {
     readonly #url: string;
+    readonly #trustKey?: string;
     readonly #procedureNames: Set<string>;
     readonly #remote: Remote;
 
     constructor(configuration: Configuration)
     {
         this.#url = configuration.url;
+        this.#trustKey = configuration.trustKey;
         this.#procedureNames = configuration.procedureNames;
         this.#remote = configuration.remote;
     }
     
     get url() { return this.#url; }
 
-    get trustKey() { return undefined; }
+    get trustKey() { return this.#trustKey; }
 
     start(): Promise<void>
     {

--- a/packages/services/src/worker/RemoteWorker.ts
+++ b/packages/services/src/worker/RemoteWorker.ts
@@ -15,6 +15,7 @@ type Configuration =
 
 export default class RemoteWorker implements Worker
 {
+    #id?: string;
     readonly #url: string;
     readonly #trustKey?: string;
     readonly #procedureNames: Set<string>;
@@ -27,6 +28,10 @@ export default class RemoteWorker implements Worker
         this.#procedureNames = configuration.procedureNames;
         this.#remote = configuration.remote;
     }
+
+    get id(): string | undefined { return this.#id; }
+
+    set id(id: string) { this.#id = id; }
     
     get url() { return this.#url; }
 

--- a/packages/services/src/worker/Worker.ts
+++ b/packages/services/src/worker/Worker.ts
@@ -3,7 +3,9 @@ import RunnerService from '../RunnerService';
 
 interface Worker extends RunnerService
 {
-   get trustKey(): string | undefined;
+   get id(): string | undefined;
+
+   set id(id: string);
 }
 
 export default Worker;

--- a/packages/services/test/gateway/LocalGateway.spec.ts
+++ b/packages/services/test/gateway/LocalGateway.spec.ts
@@ -20,14 +20,14 @@ describe('gateway/LocalGateway', () =>
             {
                 const promise = publicGateway.addWorker(emptyWorker);
     
-                expect(promise).resolves.toBeUndefined();
+                expect(promise).resolves.toBeDefined();
             });
 
         it('should add a worker with a valid trust key to a protected gateway', () =>
         {
             const promise = protectedGateway.addWorker(trustedWorker);
 
-            expect(promise).resolves.toBeUndefined();
+            expect(promise).resolves.toBeDefined();
         });
 
         it('should not add a worker with an invalid trust key to a protected gateway', () =>

--- a/packages/services/test/gateway/LocalGateway.spec.ts
+++ b/packages/services/test/gateway/LocalGateway.spec.ts
@@ -3,12 +3,14 @@ import { describe, expect, it } from 'vitest';
 
 import InvalidTrustKey from '../../src/gateway/errors/InvalidTrustKey';
 
-import { LOCAL_GATEWAYS, REMOTE_WORKERS, VALUES } from './fixtures';
+import { LOCAL_GATEWAYS, REMOTE_WORKERS } from './fixtures';
 
 const publicGateway = LOCAL_GATEWAYS.PUBLIC;
 const protectedGateway = LOCAL_GATEWAYS.PROTECTED;
 
 const emptyWorker = REMOTE_WORKERS.EMPTY;
+const trustedWorker = REMOTE_WORKERS.TRUSTED;
+const untrustedWorker = REMOTE_WORKERS.UNTRUSTED;
 
 describe('gateway/LocalGateway', () =>
 {
@@ -23,14 +25,14 @@ describe('gateway/LocalGateway', () =>
 
         it('should add a worker with a valid trust key to a protected gateway', () =>
         {
-            const promise = protectedGateway.addWorker(emptyWorker, VALUES.TRUST_KEY);
+            const promise = protectedGateway.addWorker(trustedWorker);
 
             expect(promise).resolves.toBeUndefined();
         });
 
         it('should not add a worker with an invalid trust key to a protected gateway', () =>
         {
-            const promise = protectedGateway.addWorker(emptyWorker, 'INCORRECT_ACCESS_KEY');
+            const promise = protectedGateway.addWorker(untrustedWorker);
 
             expect(promise).rejects.toEqual(new InvalidTrustKey());
         });

--- a/packages/services/test/gateway/WorkerManager.spec.ts
+++ b/packages/services/test/gateway/WorkerManager.spec.ts
@@ -64,7 +64,7 @@ describe('gateway/WorkerManager', () =>
         {
             const worker = filledManager.getWorker(WORKER_ID);
 
-            expect(worker).toEqual(REMOTE_WORKERS.FIRST)
+            expect(worker).toEqual(REMOTE_WORKERS.FIRST);
         });
 
         it('should throw an error when worker id is unknown', () =>

--- a/packages/services/test/gateway/WorkerManager.spec.ts
+++ b/packages/services/test/gateway/WorkerManager.spec.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 
 import { Request, Response, RunModes, StatusCodes, Version, ProcedureNotFound } from '@jitar/execution';
 
-import { WORKER_MANAGERS, REMOTE_WORKERS } from './fixtures';
+import { WORKER_MANAGERS, REMOTE_WORKERS, VALUES, WORKER_ID } from './fixtures';
+
+import UnknownWorker from '../../src/gateway/errors/UnknownWorker';
 
 const filledManager = WORKER_MANAGERS.FILLED;
 
@@ -53,6 +55,23 @@ describe('gateway/WorkerManager', () =>
             const secondBalancer = balancers.get('second');
             expect(secondBalancer).toBeDefined();
             expect(secondBalancer?.workers).toEqual([REMOTE_WORKERS.SECOND]);
+        });
+    });
+
+    describe('.getWorker(id)', () =>
+    {
+        it('should get a known worker by id', () =>
+        {
+            const worker = filledManager.getWorker(WORKER_ID);
+
+            expect(worker).toEqual(REMOTE_WORKERS.FIRST)
+        });
+
+        it('should throw an error when worker id is unknown', () =>
+        {
+            const result = () => filledManager.getWorker(VALUES.UNKNOWN_WORKER_ID);
+
+            expect(result).toThrow(UnknownWorker);
         });
     });
 

--- a/packages/services/test/gateway/fixtures/localGateways.fixture.ts
+++ b/packages/services/test/gateway/fixtures/localGateways.fixture.ts
@@ -4,7 +4,7 @@ import LocalGateway from '../../../src/gateway/LocalGateway';
 import { VALUES } from './values.fixture';
 
 const url = VALUES.URL;
-const trustKey = VALUES.TRUST_KEY;
+const trustKey = VALUES.VALID_TRUST_KEY;
 
 const publicGateway = new LocalGateway({ url });
 const protectedGateway = new LocalGateway({ url, trustKey});

--- a/packages/services/test/gateway/fixtures/remoteWorkers.fixture.ts
+++ b/packages/services/test/gateway/fixtures/remoteWorkers.fixture.ts
@@ -26,6 +26,9 @@ const remote = REMOTES.DUMMY;
 const noProcedureNames = new Set<string>();
 const emptyWorker = new RemoteWorker({ url, procedureNames: noProcedureNames, remote });
 
+const trustedWorker = new RemoteWorker({ url, procedureNames: noProcedureNames, remote, trustKey: VALUES.VALID_TRUST_KEY });
+const untrustedWorker = new RemoteWorker({ url, procedureNames: noProcedureNames, remote, trustKey: VALUES.INVALID_TRUST_KEY });
+
 const firstProcedureNames = new Set<string>(['first']);
 const firstWorker = new RemoteWorker({ url, procedureNames: firstProcedureNames, remote });
 
@@ -38,6 +41,8 @@ const unhealthyWorker = new UnhealthyWorker({ url, procedureNames: noProcedureNa
 export const REMOTE_WORKERS =
 {
     EMPTY: emptyWorker,
+    TRUSTED: trustedWorker,
+    UNTRUSTED: untrustedWorker,
     FIRST: firstWorker,
     SECOND: secondWorker,
     HEALTHY: healthyWorker,

--- a/packages/services/test/gateway/fixtures/remotes.fixture.ts
+++ b/packages/services/test/gateway/fixtures/remotes.fixture.ts
@@ -40,6 +40,12 @@ class DummyRemote implements Remote
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    removeWorker(workerUrl: string, trustKey?: string): Promise<void>
+    {
+        throw new NotImplemented();    
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async run(request: Request): Promise<Response>
     {
         return new Response(StatusCodes.OK, 'test');

--- a/packages/services/test/gateway/fixtures/remotes.fixture.ts
+++ b/packages/services/test/gateway/fixtures/remotes.fixture.ts
@@ -34,7 +34,7 @@ class DummyRemote implements Remote
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    addWorker(workerUrl: string, procedureNames: string[], trustKey?: string): Promise<void>
+    addWorker(workerUrl: string, procedureNames: string[], trustKey?: string): Promise<string>
     {
         throw new NotImplemented();
     }

--- a/packages/services/test/gateway/fixtures/values.fixture.ts
+++ b/packages/services/test/gateway/fixtures/values.fixture.ts
@@ -2,5 +2,6 @@
 export const VALUES =
 {
     URL: 'http://localhost:80',
-    TRUST_KEY: 'MY_TRUSTED_ACCESS_KEY'
+    VALID_TRUST_KEY: 'MY_TRUSTED_ACCESS_KEY',
+    INVALID_TRUST_KEY: 'INCORRECT_ACCESS_KEY'
 };

--- a/packages/services/test/gateway/fixtures/values.fixture.ts
+++ b/packages/services/test/gateway/fixtures/values.fixture.ts
@@ -3,5 +3,6 @@ export const VALUES =
 {
     URL: 'http://localhost:80',
     VALID_TRUST_KEY: 'MY_TRUSTED_ACCESS_KEY',
-    INVALID_TRUST_KEY: 'INCORRECT_ACCESS_KEY'
+    INVALID_TRUST_KEY: 'INCORRECT_ACCESS_KEY',
+    UNKNOWN_WORKER_ID: 'unknown id'
 };

--- a/packages/services/test/gateway/fixtures/workerManagers.fixture.ts
+++ b/packages/services/test/gateway/fixtures/workerManagers.fixture.ts
@@ -4,10 +4,12 @@ import WorkerManager from '../../../src/gateway/WorkerManager';
 import { REMOTE_WORKERS } from './remoteWorkers.fixture';
 
 const filledManager = new WorkerManager();
-filledManager.addWorker(REMOTE_WORKERS.FIRST);
+const WORKER_ID = filledManager.addWorker(REMOTE_WORKERS.FIRST);
 filledManager.addWorker(REMOTE_WORKERS.SECOND);
 
-export const WORKER_MANAGERS =
+const WORKER_MANAGERS =
 {
     FILLED: filledManager
 };
+
+export { WORKER_MANAGERS, WORKER_ID }

--- a/packages/services/test/gateway/fixtures/workerManagers.fixture.ts
+++ b/packages/services/test/gateway/fixtures/workerManagers.fixture.ts
@@ -12,4 +12,4 @@ const WORKER_MANAGERS =
     FILLED: filledManager
 };
 
-export { WORKER_MANAGERS, WORKER_ID }
+export { WORKER_MANAGERS, WORKER_ID };


### PR DESCRIPTION
Fixes #409

Changes proposed in this pull request:
- prevent shutdown signal to be processed more than once
- remove worker from gateway when worker is signaled to shutdown

@MaskingTechnology/jitar
