### PR TITLE
chore: await uncaught promises in tests

### DIFF
--- a/packages/execution/test/ExecutionManager.spec.ts
+++ b/packages/execution/test/ExecutionManager.spec.ts
@@ -23,7 +23,7 @@ describe('ExecutionManager', () =>
         {
             const promise = executionManager.addSegment({} as Segment);
 
-            expect(promise).rejects.toEqual(new InvalidSegment());
+            await expect(promise).rejects.toEqual(new InvalidSegment());
         });
     });
 
@@ -35,16 +35,16 @@ describe('ExecutionManager', () =>
 
             const response = await executionManager.run(request);
 
-            expect(response.result).toBe('public');
+            await expect(response.result).toBe('public');
         });
 
-        it('should not run a non-existing procedure', () =>
+        it('should not run a non-existing procedure', async () =>
         {
             const request = new Request('nonExisting', Version.DEFAULT, new Map(), new Map(), RunModes.NORMAL);
 
             const promise = executionManager.run(request);
 
-            expect(promise).rejects.toEqual(new ProcedureNotFound('nonExisting'));
+            await expect(promise).rejects.toEqual(new ProcedureNotFound('nonExisting'));
         });
 
         it('should not run a non-existing implementation', async () =>
@@ -53,7 +53,7 @@ describe('ExecutionManager', () =>
 
             const promise = executionManager.run(request);
 
-            expect(promise).rejects.toEqual(new ImplementationNotFound('versioned', Version.DEFAULT.toString()));
+            await expect(promise).rejects.toEqual(new ImplementationNotFound('versioned', Version.DEFAULT.toString()));
         });
 
         it('should perform a dry-run', async () =>
@@ -62,7 +62,7 @@ describe('ExecutionManager', () =>
 
             const response = await executionManager.run(request);
 
-            expect(response.result).toBeUndefined();
+            await expect(response.result).toBeUndefined();
         });
     });
 });

--- a/packages/serialization/test/Serializer.spec.ts
+++ b/packages/serialization/test/Serializer.spec.ts
@@ -33,7 +33,7 @@ describe('Serializer', () =>
         {
             const serialize = async () => typeSerializer.serialize(true);
 
-            expect(serialize).rejects.toStrictEqual(new NoSerializerFound('boolean'));
+            await expect(serialize).rejects.toStrictEqual(new NoSerializerFound('boolean'));
         });
     });
 
@@ -59,7 +59,7 @@ describe('Serializer', () =>
         {
             const deserialize = async () => typeSerializer.deserialize(true);
 
-            expect(deserialize).rejects.toStrictEqual(new NoDeserializerFound('boolean'));
+            await expect(deserialize).rejects.toStrictEqual(new NoDeserializerFound('boolean'));
         });
     });
 });

--- a/packages/serialization/test/serializers/BigIntSerializer.spec.ts
+++ b/packages/serialization/test/serializers/BigIntSerializer.spec.ts
@@ -68,14 +68,14 @@ describe('serializers/BigIntSerializer', () =>
         {
             const resultValidBigInt = await serializer.deserialize(BIG_INTEGERS.VALID_SERIALIZED);
 
-            expect(resultValidBigInt).toStrictEqual(BIG_INTEGERS.VALID);
+            await expect(resultValidBigInt).toStrictEqual(BIG_INTEGERS.VALID);
         });
 
         it('should not deserialize a big int with an invalid big int string', async () =>
         {
             const deserialize = async () => serializer.deserialize(BIG_INTEGERS.INVALID_BIGINT_STRING);
 
-            expect(deserialize).rejects.toStrictEqual(new InvalidBigIntString('1.3'));
+            await expect(deserialize).rejects.toStrictEqual(new InvalidBigIntString('1.3'));
         });
     });
 });

--- a/packages/serialization/test/serializers/ClassSerializer.spec.ts
+++ b/packages/serialization/test/serializers/ClassSerializer.spec.ts
@@ -98,14 +98,14 @@ describe('serializers/ClassSerializer', () =>
         {
             const deserialize = async () => serializer.deserialize(CLASSES.INVALID_SERIALIZED);
 
-            expect(deserialize).rejects.toStrictEqual(new ClassNotFound('Invalid'));
+            await expect(deserialize).rejects.toStrictEqual(new ClassNotFound('Invalid'));
         });
 
         it('should not deserialize non-function instances', async () =>
         {
             const deserialize = async () => serializer.deserialize(CLASSES.UNSERIALIZABLE);
 
-            expect(deserialize).rejects.toStrictEqual(new InvalidClass('Infinity'));
+            await expect(deserialize).rejects.toStrictEqual(new InvalidClass('Infinity'));
         });
     });
 });

--- a/packages/serialization/test/serializers/DateSerializer.spec.ts
+++ b/packages/serialization/test/serializers/DateSerializer.spec.ts
@@ -75,7 +75,7 @@ describe('serializers/DateSerializer', () =>
         {
             const deserialize = async () => serializer.deserialize(DATES.INVALID_DATE_STRING);
 
-            expect(deserialize).rejects.toStrictEqual(new InvalidDateString('hello'));
+            await expect(deserialize).rejects.toStrictEqual(new InvalidDateString('hello'));
         });
     });
 });

--- a/packages/serialization/test/serializers/RegExpSerializer.spec.ts
+++ b/packages/serialization/test/serializers/RegExpSerializer.spec.ts
@@ -77,14 +77,14 @@ describe('serializers/RegExpSerializer', () =>
         {
             const deserialize = async () => serializer.deserialize(REGULAR_EXPRESSIONS.INVALID_SOURCE_SERIALIZED);
 
-            expect(deserialize).rejects.toStrictEqual(new InvalidRegExp('sel/\\', 'g'));
+            await expect(deserialize).rejects.toStrictEqual(new InvalidRegExp('sel/\\', 'g'));
         });
 
         it('should not deserialize a regular expression with invalid flag', async () =>
         {
             const deserialize = async () => serializer.deserialize(REGULAR_EXPRESSIONS.INVALID_FLAG_SERIALIZED);
 
-            expect(deserialize).rejects.toStrictEqual(new InvalidRegExp('w+', true));
+            await expect(deserialize).rejects.toStrictEqual(new InvalidRegExp('\\w+', true));
         });
     });
 });

--- a/packages/serialization/test/serializers/UrlSerializer.spec.ts
+++ b/packages/serialization/test/serializers/UrlSerializer.spec.ts
@@ -75,7 +75,7 @@ describe('serializers/UrlSerializer', () =>
         {
             const deserialize = async () => serializer.deserialize(URLS.INVALID_URL_STRING);
 
-            expect(deserialize).rejects.toStrictEqual(new InvalidUrlString('example'));
+            await expect(deserialize).rejects.toStrictEqual(new InvalidUrlString('example'));
         });
     });
 });

--- a/packages/serialization/test/serializers/fixtures/regularExpressions.fixture.ts
+++ b/packages/serialization/test/serializers/fixtures/regularExpressions.fixture.ts
@@ -1,16 +1,16 @@
 
-const validRegExp = new RegExp('w+', 'gi');
+const validRegExp = /\w+/gi;
 
-const serializedValidRegExp = { serialized: true, name: 'RegExp', source: 'w+', flags: 'gi' };
+const serializedValidRegExp = { serialized: true, name: 'RegExp', source: '\\w+', flags: 'gi' };
 
 const nonObject = 42;
 const nonRegExp = new Map();
-const notSerialized = { name: 'RegExp', source: 'w+', flags: 'gi' };
-const invalidName = { serialized: true, name: 'Map', source: 'w+', flags: 'gi' };
+const notSerialized = { name: 'RegExp', source: '\\w+', flags: 'gi' };
+const invalidName = { serialized: true, name: 'Map', source: '\\w+', flags: 'gi' };
 const invalidRegExpSource = { serialized: true, name: 'RegExp', source: true, flags: 'g' };
-const invalidRegExpFlag = { serialized: true, name: 'RegExp', source: 'w+', flags: true };
+const invalidRegExpFlag = { serialized: true, name: 'RegExp', source: '\\w+', flags: true };
 const serializedInvalidRegExpSource = { serialized: true, name: 'RegExp', source: 'sel/\\', flags: 'g' };
-const serializedInvalidRegExpFlag = { serialized: true, name: 'RegExp', source: 'w+', flags: 'true' };
+const serializedInvalidRegExpFlag = { serialized: true, name: 'RegExp', source: '\\w+', flags: 'true' };
 
 export const REGULAR_EXPRESSIONS =
 {

--- a/packages/services/src/gateway/errors/UnknownWorker.ts
+++ b/packages/services/src/gateway/errors/UnknownWorker.ts
@@ -3,7 +3,7 @@ import { ServerError } from '@jitar/errors';
 
 export default class UnknownWorker extends ServerError
 {
-    #id: string;
+    readonly #id: string;
 
     constructor(id: string)
     {

--- a/packages/services/test/gateway/LocalGateway.spec.ts
+++ b/packages/services/test/gateway/LocalGateway.spec.ts
@@ -16,32 +16,32 @@ describe('gateway/LocalGateway', () =>
 {
     describe('.addWorker(worker, trustKey?)', () =>
     {
-        it('should add a worker without a trust key to a public gateway', () =>
+        it('should add a worker without a trust key to a public gateway', async () =>
             {
                 const promise = publicGateway.addWorker(emptyWorker);
     
-                expect(promise).resolves.toBeDefined();
+                await expect(promise).resolves.toBeDefined();
             });
 
-        it('should add a worker with a valid trust key to a protected gateway', () =>
+        it('should add a worker with a valid trust key to a protected gateway', async () =>
         {
             const promise = protectedGateway.addWorker(trustedWorker);
 
-            expect(promise).resolves.toBeDefined();
+            await expect(promise).resolves.toBeDefined();
         });
 
-        it('should not add a worker with an invalid trust key to a protected gateway', () =>
+        it('should not add a worker with an invalid trust key to a protected gateway', async () =>
         {
             const promise = protectedGateway.addWorker(untrustedWorker);
 
-            expect(promise).rejects.toEqual(new InvalidTrustKey());
+            await expect(promise).rejects.toEqual(new InvalidTrustKey());
         });
 
-        it('should not add a worker with a missing trust key to a protected gateway', () =>
+        it('should not add a worker with a missing trust key to a protected gateway', async () =>
         {
             const promise = protectedGateway.addWorker(emptyWorker);
 
-            expect(promise).rejects.toEqual(new InvalidTrustKey());
+            await expect(promise).rejects.toEqual(new InvalidTrustKey());
         });
     });
 });

--- a/packages/services/test/gateway/WorkerBalancer.spec.ts
+++ b/packages/services/test/gateway/WorkerBalancer.spec.ts
@@ -35,7 +35,7 @@ describe('services/WorkerBalancer', () =>
             const request = new Request('nonExisting', Version.DEFAULT, new Map(), new Map(), RunModes.NORMAL);
             const promise = emptyBalancer.run(request);
 
-            expect(promise).rejects.toEqual(new NoWorkerAvailable('nonExisting'));
+            await expect(promise).rejects.toEqual(new NoWorkerAvailable('nonExisting'));
         });
     });
 });

--- a/packages/services/test/gateway/WorkerManager.spec.ts
+++ b/packages/services/test/gateway/WorkerManager.spec.ts
@@ -77,22 +77,22 @@ describe('gateway/WorkerManager', () =>
 
     describe('.run(request)', () =>
     {
-        it('should run an existing procedure', () =>
+        it('should run an existing procedure', async () =>
         {
             const request = new Request('first', Version.DEFAULT, new Map(), new Map(), RunModes.NORMAL);
 
             const promise = filledManager.run(request);
 
-            expect(promise).resolves.toEqual(new Response(StatusCodes.OK, 'test'));
+            await expect(promise).resolves.toEqual(new Response(StatusCodes.OK, 'test'));
         });
 
-        it('should not run a non-existing procedure', () =>
+        it('should not run a non-existing procedure', async () =>
         {
             const request = new Request('nonExisting', Version.DEFAULT, new Map(), new Map(), RunModes.NORMAL);
 
             const promise = filledManager.run(request);
 
-            expect(promise).rejects.toEqual(new ProcedureNotFound('nonExisting'));
+            await expect(promise).rejects.toEqual(new ProcedureNotFound('nonExisting'));
         });
     });
 });

--- a/packages/services/test/repository/LocalRepository.spec.ts
+++ b/packages/services/test/repository/LocalRepository.spec.ts
@@ -12,25 +12,25 @@ describe('repository/LocalRepository', () =>
 {
     describe('.provide(filename)', () =>
     {
-        it('should provide a existing file', () =>
+        it('should provide a existing file', async () =>
         {
             const promise = fileRepository.provide(FILENAMES.PNG);
 
-            expect(promise).resolves.toEqual(FILES.PNG);
+            await expect(promise).resolves.toEqual(FILES.PNG);
         });
 
-        it('should not provide a non-existing file', () =>
+        it('should not provide a non-existing file', async () =>
         {
             const promise = fileRepository.provide(FILENAMES.TXT);
 
-            expect(promise).rejects.toEqual(new FileNotFound(FILENAMES.TXT));
+            await expect(promise).rejects.toEqual(new FileNotFound(FILENAMES.TXT));
         });
 
-        it('should provide index file when file not found', () =>
+        it('should provide index file when file not found', async () =>
         {
             const promise = webRepository.provide(FILENAMES.TXT);
 
-            expect(promise).resolves.toEqual(FILES.HTML);
+            await expect(promise).resolves.toEqual(FILES.HTML);
         });
     });
 });

--- a/packages/services/test/worker/LocalWorker.spec.ts
+++ b/packages/services/test/worker/LocalWorker.spec.ts
@@ -40,7 +40,7 @@ describe('worker/LocalWorker', () =>
 
             const promise = protectedWorker.run(request);
 
-            expect(promise).rejects.toEqual(new ProcedureNotFound('nonExisting'));
+            await expect(promise).rejects.toEqual(new ProcedureNotFound('nonExisting'));
         });
 
         it('should not run a protected procedure with invalid trust key', async () =>
@@ -50,7 +50,7 @@ describe('worker/LocalWorker', () =>
 
             const promise = protectedWorker.run(request);
 
-            expect(promise).rejects.toEqual(new RequestNotTrusted());
+            await expect(promise).rejects.toEqual(new RequestNotTrusted());
         });
 
         it('should not run a protected procedure without trust key', async () =>
@@ -59,7 +59,7 @@ describe('worker/LocalWorker', () =>
 
             const promise = protectedWorker.run(request);
 
-            expect(promise).rejects.toEqual(new RequestNotTrusted());
+            await expect(promise).rejects.toEqual(new RequestNotTrusted());
         });
 
         // TODO: Add tests for remote execution


### PR DESCRIPTION
Fixes #581

Changes proposed in this pull request:
- Vitest 3 is going to change the way unhandled promises are handled, these should be awaited by us. The warning is already present in Vitest 2, so better be prepared.

@MaskingTechnology/jitar
