### PR TITLE
#616: adding buffer serializer if Buffer class available

### DIFF
--- a/packages/serialization/src/SerializerBuilder.ts
+++ b/packages/serialization/src/SerializerBuilder.ts
@@ -38,7 +38,11 @@ export default class SerializerBuilder
         serializer.addSerializer(new MapSerializer());
         serializer.addSerializer(new ArraySerializer());
         serializer.addSerializer(new TypedArraySerializer());
-        serializer.addSerializer(new BufferSerializer());
+
+        if (typeof Buffer !== 'undefined')
+        {
+            serializer.addSerializer(new BufferSerializer());
+        }
 
         return serializer;
     }


### PR DESCRIPTION
Fixes #616 

Changes proposed in this pull request:
- Check if `Buffer` class is available before adding its serializer

@MaskingTechnology/jitar
