### PR TITLE
chore: clean up templates

### DIFF
--- a/packages/create-jitar/templates/react/index.html
+++ b/packages/create-jitar/templates/react/index.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/packages/create-jitar/templates/react/index.html
+++ b/packages/create-jitar/templates/react/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/packages/create-jitar/templates/react/index.html
+++ b/packages/create-jitar/templates/react/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Vite + React + Jitar</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/create-jitar/templates/react/package.json
+++ b/packages/create-jitar/templates/react/package.json
@@ -11,16 +11,17 @@
     "standalone": "jitar start --service=services/standalone.json"
   },
   "dependencies": {
-    "jitar": "^0.9.0",
+    "jitar": "^0.9.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@jitar/plugin-vite": "^0.9.0",
-    "@types/react": "^19.1.4",
+    "@jitar/plugin-vite": "^0.9.2",
+    "@types/node": "22.15.27",
+    "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
-    "@vitejs/plugin-react": "^4.3.1",
-    "typescript": "^5.5.3",
+    "@vitejs/plugin-react": "^4.5.0",
+    "typescript": "^5.8.3",
     "vite": "^6.3.5"
   }
 }

--- a/packages/create-jitar/templates/react/src/domain/sayHello.ts
+++ b/packages/create-jitar/templates/react/src/domain/sayHello.ts
@@ -1,5 +1,5 @@
 
 export async function sayHello(name: string): Promise<string>
 {
-    return `Hello, ${name}!`
+    return `Hello, ${name}!`;
 }

--- a/packages/create-jitar/templates/react/src/domain/sayHello.ts
+++ b/packages/create-jitar/templates/react/src/domain/sayHello.ts
@@ -1,3 +1,4 @@
+
 export async function sayHello(name: string): Promise<string>
 {
     return `Hello, ${name}!`

--- a/packages/create-jitar/templates/react/src/webui/App.tsx
+++ b/packages/create-jitar/templates/react/src/webui/App.tsx
@@ -20,13 +20,13 @@ export default function App()
 
   return (
     <div className="App">
-      <a href="https://vitejs.dev" target="_blank">
+      <a href="https://vitejs.dev" target="_blank" rel="noopener noreferrer">
           <img src="/vite.svg" className="logo" alt="Vite logo" />
         </a>
-        <a href="https://reactjs.org" target="_blank">
+        <a href="https://reactjs.org" target="_blank" rel="noopener noreferrer">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
-        <a href="https://jitar.dev" target="_blank">
+        <a href="https://jitar.dev" target="_blank" rel="noopener noreferrer">
           <img src={jitarLogo} className="logo jitar" alt="Jitar logo" />
         </a>
       <h1>{message}</h1>

--- a/packages/create-jitar/templates/react/src/webui/App.tsx
+++ b/packages/create-jitar/templates/react/src/webui/App.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useState } from 'react'
 
-import './App.css'
-import reactLogo from './assets/react.svg'
-import jitarLogo from './assets/jitar.svg'
+import { useEffect, useState } from 'react';
 
-import { sayHello } from '../domain/sayHello'
+import './App.css';
+import reactLogo from './assets/react.svg';
+import jitarLogo from './assets/jitar.svg';
 
-function App()
+import { sayHello } from '../domain/sayHello';
+
+export default function App()
 {
   const [message, setMessage] = useState<string>('Loading...');
 
@@ -32,5 +33,3 @@ function App()
     </div>
   )
 }
-
-export default App

--- a/packages/create-jitar/templates/react/src/webui/jitar.ts
+++ b/packages/create-jitar/templates/react/src/webui/jitar.ts
@@ -1,9 +1,0 @@
-
-import { buildServer } from 'jitar';
-
-const moduleImporter = async (specifier: string) => import(specifier);
-const server = await buildServer(moduleImporter);
-
-process.on('SIGINT', async () => server.stop());
-
-server.start();

--- a/packages/create-jitar/templates/react/src/webui/main.tsx
+++ b/packages/create-jitar/templates/react/src/webui/main.tsx
@@ -9,4 +9,4 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
-)
+);

--- a/packages/create-jitar/templates/react/src/webui/main.tsx
+++ b/packages/create-jitar/templates/react/src/webui/main.tsx
@@ -1,7 +1,9 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import './index.css'
+
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import App from './App';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/packages/create-jitar/templates/react/vite.config.ts
+++ b/packages/create-jitar/templates/react/vite.config.ts
@@ -11,4 +11,4 @@ export default defineConfig({
     react(),
     jitar({ sourceDir: 'src', targetDir: 'dist', jitarDir: 'domain', jitarUrl: 'http://localhost:3000', segments: [] })
   ]
-})
+});

--- a/packages/create-jitar/templates/react/vite.config.ts
+++ b/packages/create-jitar/templates/react/vite.config.ts
@@ -1,3 +1,4 @@
+
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import jitar from '@jitar/plugin-vite';

--- a/packages/create-jitar/templates/vue/index.html
+++ b/packages/create-jitar/templates/vue/index.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/packages/create-jitar/templates/vue/index.html
+++ b/packages/create-jitar/templates/vue/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/packages/create-jitar/templates/vue/index.html
+++ b/packages/create-jitar/templates/vue/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Vue + TS</title>
+    <title>Vite + Vue + Jitar</title>
   </head>
   <body>
     <div id="app"></div>

--- a/packages/create-jitar/templates/vue/package.json
+++ b/packages/create-jitar/templates/vue/package.json
@@ -11,13 +11,14 @@
     "standalone": "jitar start --service=services/standalone.json"
   },
   "dependencies": {
-    "jitar": "^0.9.0",
-    "vue": "^3.5.14"
+    "jitar": "^0.9.2",
+    "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@jitar/plugin-vite": "^0.9.0",
+    "@types/node": "22.15.27",
+    "@jitar/plugin-vite": "^0.9.2",
     "@vitejs/plugin-vue": "^5.2.4",
-    "typescript": "^5.5.3",
+    "typescript": "^5.8.3",
     "vite": "^6.3.5",
     "vue-tsc": "^2.2.10"
   }

--- a/packages/create-jitar/templates/vue/src/domain/sayHello.ts
+++ b/packages/create-jitar/templates/vue/src/domain/sayHello.ts
@@ -1,5 +1,5 @@
 
 export async function sayHello(name: string): Promise<string>
 {
-    return `Hello, ${name}!`
+    return `Hello, ${name}!`;
 }

--- a/packages/create-jitar/templates/vue/src/domain/sayHello.ts
+++ b/packages/create-jitar/templates/vue/src/domain/sayHello.ts
@@ -1,3 +1,4 @@
+
 export async function sayHello(name: string): Promise<string>
 {
     return `Hello, ${name}!`

--- a/packages/create-jitar/templates/vue/src/webui/App.vue
+++ b/packages/create-jitar/templates/vue/src/webui/App.vue
@@ -9,7 +9,7 @@ async function runComponent() {
   message.value = await sayHello('Vite + Vue + Jitar');
 }
 
-runComponent()
+runComponent();
 
 </script>
 

--- a/packages/create-jitar/templates/vue/src/webui/App.vue
+++ b/packages/create-jitar/templates/vue/src/webui/App.vue
@@ -21,7 +21,7 @@ runComponent()
     <a href="https://vuejs.org/" target="_blank">
       <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />
     </a>
-    <a href="https://jitar.dev/" target="_blank">
+    <a href="https://jitar.dev" target="_blank">
       <img src="./assets/jitar.svg" class="logo jitar" alt="Jitar logo" />
     </a>
   </div>

--- a/packages/create-jitar/templates/vue/src/webui/App.vue
+++ b/packages/create-jitar/templates/vue/src/webui/App.vue
@@ -15,13 +15,13 @@ runComponent()
 
 <template>
   <div>
-    <a href="https://vitejs.dev" target="_blank">
+    <a href="https://vitejs.dev" target="_blank" rel="noopener noreferrer">
       <img src="/vite.svg" class="logo" alt="Vite logo" />
     </a>
-    <a href="https://vuejs.org/" target="_blank">
+    <a href="https://vuejs.org/" target="_blank" rel="noopener noreferrer">
       <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />
     </a>
-    <a href="https://jitar.dev" target="_blank">
+    <a href="https://jitar.dev" target="_blank" rel="noopener noreferrer">
       <img src="./assets/jitar.svg" class="logo jitar" alt="Jitar logo" />
     </a>
   </div>

--- a/packages/create-jitar/templates/vue/src/webui/main.ts
+++ b/packages/create-jitar/templates/vue/src/webui/main.ts
@@ -1,5 +1,7 @@
-import { createApp } from 'vue'
-import './style.css'
-import App from './App.vue'
 
-createApp(App).mount('#app')
+import { createApp } from 'vue';
+
+import './style.css';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/packages/create-jitar/templates/vue/vite.config.ts
+++ b/packages/create-jitar/templates/vue/vite.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
-import jitar from '@jitar/plugin-vite'
+
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import jitar from '@jitar/plugin-vite';
 
 export default defineConfig({
   build: {

--- a/packages/create-jitar/templates/vue/vite.config.ts
+++ b/packages/create-jitar/templates/vue/vite.config.ts
@@ -11,4 +11,4 @@ export default defineConfig({
     vue(),
     jitar({ sourceDir: 'src', targetDir: 'dist', jitarDir: 'domain', jitarUrl: 'http://localhost:3000', segments: [] })
   ]
-})
+});


### PR DESCRIPTION
Fixes #643

Changes proposed in this pull request:
- removed old jitar.ts file
- applied our own coding style

@MaskingTechnology/jitar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added type definitions for Node.js in both React and Vue starter templates.

- **Bug Fixes**
  - Corrected the URL in the Vue starter template's link to remove an unnecessary trailing slash.

- **Chores**
  - Updated several dependencies to newer versions in both React and Vue starter templates for improved compatibility and stability.
  - Removed an unused server script from the React starter template.
  - Updated HTML titles in React and Vue templates to reflect "Jitar" branding.

- **Style**
  - Applied consistent formatting improvements, such as adding semicolons, blank lines, and newlines across multiple files.
  - Enhanced security by adding `rel="noopener noreferrer"` to external links opening in new tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->