### PR TITLE
fix: plugin loading order

### DIFF
--- a/packages/health/src/HealthManager.ts
+++ b/packages/health/src/HealthManager.ts
@@ -35,9 +35,9 @@ export default class HealthManager
 
     async loadHealthCheck(filename: string): Promise<void>
     {
-        const module = await this.#moduleImporter.import(filename);
+        const healthCheck = await this.#loadHealthCheck(filename);
 
-        this.addHealthCheck(module.default as HealthCheck);
+        this.addHealthCheck(healthCheck);
     }
 
     addHealthCheck(healthCheck: HealthCheck): void
@@ -93,7 +93,16 @@ export default class HealthManager
 
     async #loadHealthChecks(): Promise<void>
     {
-        await Promise.all(this.#healthCheckFiles.map(filename => this.loadHealthCheck(filename)));
+        const healthChecks = await Promise.all(this.#healthCheckFiles.map(filename => this.#loadHealthCheck(filename)));
+
+        healthChecks.forEach(healthCheck => this.addHealthCheck(healthCheck));
+    }
+
+    async #loadHealthCheck(filename: string): Promise<HealthCheck>
+    {
+        const module = await this.#moduleImporter.import(filename);
+
+        return module.default as HealthCheck;
     }
 
     #handleHealthCheckResult(result: PromiseSettledResult<HealthCheckResult>, healthChecks: Map<string, boolean>): void

--- a/packages/middleware/src/MiddlewareManager.ts
+++ b/packages/middleware/src/MiddlewareManager.ts
@@ -29,11 +29,11 @@ export default class MiddlewareManager
         return this.clearMiddlewares();
     }
 
-    async loadMiddleware(filename:string): Promise<void>
+    async loadMiddleware(filename: string): Promise<void>
     {
-        const module = await this.#moduleImporter.import(filename);
+        const middleware = await this.#loadMiddleware(filename);
 
-        this.addMiddleware(module.default as Middleware);
+        this.addMiddleware(middleware);
     }
 
     addMiddleware(middleware: Middleware): void
@@ -67,7 +67,16 @@ export default class MiddlewareManager
 
     async #loadMiddlewares(): Promise<void>
     {
-        await Promise.all(this.#middlewareFiles.map(filename => this.loadMiddleware(filename)));
+        const middlewares = await Promise.all(this.#middlewareFiles.map(filename => this.#loadMiddleware(filename)));
+
+        middlewares.forEach(middleware => this.addMiddleware(middleware));
+    }
+
+    async #loadMiddleware(filename: string): Promise<Middleware>
+    {
+        const module = await this.#moduleImporter.import(filename);
+
+        return module.default as Middleware;
     }
 
     #getNextHandler(request: Request, index: number): NextHandler


### PR DESCRIPTION
Fixes #660 

Changes proposed in this pull request:
- Loads all middleware before adding them in the correct order
- Applied same strategy to the health checks

@MaskingTechnology/jitar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the loading process for health checks and middleware, resulting in more efficient internal handling and future maintainability. No changes to user-facing features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->